### PR TITLE
Add Dot Product and Norm using MPI

### DIFF
--- a/pylops_mpi/DistributedArray.py
+++ b/pylops_mpi/DistributedArray.py
@@ -356,7 +356,7 @@ class DistributedArray:
             Flatten the array before computing vector norms.
         """
         if flatten:
-            # Flatten the local arrays and calulcate norm
+            # Flatten the local arrays and calculate norm
             return self._compute_vector_norm(self.local_array.flatten(), axis=0, ord=ord)  # if local array is not 1-d
         # This will calculate vector norm along the partition axis for ND arrays
         return self._compute_vector_norm(self.local_array, axis=self.axis, ord=ord)

--- a/pylops_mpi/DistributedArray.py
+++ b/pylops_mpi/DistributedArray.py
@@ -311,10 +311,20 @@ class DistributedArray:
         self._check_partition_shape(dist_array)
         if self.ndim == 1 and dist_array.ndim == 1:
             return self._allreduce(np.dot(self.local_array, dist_array.local_array))
-        pass
 
     def _compute_vector_norm(self, local_array: NDArray,
                              axis: int, ord: Optional[int] = None):
+        """Compute Vector norm using MPI
+
+        Parameters
+        ----------
+        local_array : :obj:`numpy.ndarray`
+            Local Array at each rank
+        axis : :obj:`int`
+            Axis along which norm is computed
+        ord : :obj:`int`, optional
+            Order of the norm
+        """
         # Compute along any axis
         ord = 2 if ord is None else ord
         if local_array.ndim == 1:

--- a/pylops_mpi/DistributedArray.py
+++ b/pylops_mpi/DistributedArray.py
@@ -344,21 +344,23 @@ class DistributedArray:
             recv_buf = np.power(recv_buf, 1. / ord)
         return recv_buf
 
-    def norm(self, ord=None,
-             flatten: bool = False):
+    def norm(self, ord: Optional[int] = None,
+             axis: int = -1):
         """Distributed numpy.linalg.norm method
 
         Parameters
         ----------
         ord : :obj:`int`, optional
-            Order of the norm
-        flatten : :obj:`bool`, optional
-            Flatten the array before computing vector norms.
+            Order of the norm.
+        axis : :obj:`int`, optional
+            Axis along which vector norm needs to be computed. Defaults to ``-1``
         """
-        if flatten:
+        if axis == -1:
             # Flatten the local arrays and calculate norm
-            return self._compute_vector_norm(self.local_array.flatten(), axis=0, ord=ord)  # if local array is not 1-d
-        # This will calculate vector norm along the partition axis for ND arrays
+            return self._compute_vector_norm(self.local_array.flatten(), axis=0, ord=ord)
+        if axis != self.axis:
+            raise NotImplementedError("Choose axis along the partition.")
+        # Calculate vector norm along the axis
         return self._compute_vector_norm(self.local_array, axis=self.axis, ord=ord)
 
     def __repr__(self):

--- a/tests/test_distributedarray.py
+++ b/tests/test_distributedarray.py
@@ -129,8 +129,12 @@ def test_distributed_dot(par1, par2):
 def test_distributed_norm(par):
     """Test Distributed norm method"""
     arr = DistributedArray.to_dist(x=par['x'], axis=par['axis'])
-    assert_array_almost_equal(arr.norm(ord=1), np.linalg.norm(par['x'], ord=1, axis=par['axis']),
-                              decimal=3)
-    assert_array_almost_equal(arr.norm(ord=np.inf), np.linalg.norm(par['x'], ord=np.inf, axis=par['axis']),
-                              decimal=3)
-    assert_almost_equal(arr.norm(flatten=True), np.linalg.norm(par['x'].flatten()))
+    assert_array_almost_equal(arr.norm(ord=1, axis=par['axis']),
+                              np.linalg.norm(par['x'], ord=1, axis=par['axis']), decimal=3)
+    with pytest.raises(NotImplementedError):
+        arr.norm(ord=1, axis=0)
+    assert_array_almost_equal(arr.norm(ord=np.inf, axis=par['axis']),
+                              np.linalg.norm(par['x'], ord=np.inf, axis=par['axis']), decimal=3)
+    with pytest.raises(NotImplementedError):
+        arr.norm(ord=np.inf, axis=0)
+    assert_almost_equal(arr.norm(), np.linalg.norm(par['x'].flatten()))

--- a/tests/test_distributedarray.py
+++ b/tests/test_distributedarray.py
@@ -4,7 +4,7 @@
 """
 import numpy as np
 import pytest
-from numpy.testing import assert_array_almost_equal, assert_almost_equal, assert_allclose
+from numpy.testing import assert_array_almost_equal, assert_allclose
 
 from pylops_mpi import DistributedArray, Partition
 from pylops_mpi.DistributedArray import local_split
@@ -137,7 +137,7 @@ def test_distributed_dot(par1, par2):
     """Test Distributed Dot product"""
     arr1 = DistributedArray.to_dist(x=par1['x'], partition=par1['partition'], axis=par1['axis'])
     arr2 = DistributedArray.to_dist(x=par2['x'], partition=par2['partition'], axis=par2['axis'])
-    assert_almost_equal(arr1.dot(arr2), np.dot(par1['x'].flatten(), par2['x'].flatten()), decimal=3)
+    assert_allclose(arr1.dot(arr2), np.dot(par1['x'].flatten(), par2['x'].flatten()), rtol=1e-14)
 
 
 @pytest.mark.mpi(min_size=2)

--- a/tests/test_distributedarray.py
+++ b/tests/test_distributedarray.py
@@ -147,7 +147,7 @@ def test_distributed_norm(par):
     """Test Distributed numpy.linalg.norm method"""
     arr = DistributedArray.to_dist(x=par['x'], axis=par['axis'])
     assert_allclose(arr.norm(ord=1, axis=par['axis']),
-                              np.linalg.norm(par['x'], ord=1, axis=par['axis']), rtol=1e-14)
+                    np.linalg.norm(par['x'], ord=1, axis=par['axis']), rtol=1e-14)
     assert_allclose(arr.norm(ord=np.inf, axis=par['axis']),
-                              np.linalg.norm(par['x'], ord=np.inf, axis=par['axis']), rtol=1e-14)
+                    np.linalg.norm(par['x'], ord=np.inf, axis=par['axis']), rtol=1e-14)
     assert_allclose(arr.norm(), np.linalg.norm(par['x'].flatten()), rtol=1e-14)

--- a/tests/test_distributedarray.py
+++ b/tests/test_distributedarray.py
@@ -24,28 +24,42 @@ par2j = {'global_shape': (501, 500),
          'partition': Partition.BROADCAST, 'dtype': np.complex128,
          'axis': 0}
 
-par3_1 = {'x': np.random.normal(100, 100, (500, 501)),
-          'partition': Partition.SCATTER, 'axis': 1}
-par3_2 = {'x': np.random.normal(300, 300, (500, 501)),
-          'partition': Partition.SCATTER, 'axis': 1}
-
-par4_1 = {'x': np.random.normal(100, 100, (500, 501)),
-          'partition': Partition.BROADCAST, 'axis': 0}
-par4_2 = {'x': np.random.normal(300, 300, (500, 501)),
-          'partition': Partition.BROADCAST, 'axis': 0}
-
-par5 = {'global_shape': (200, 201, 101),
+par3 = {'global_shape': (200, 201, 101),
         'partition': Partition.SCATTER,
         'dtype': np.float64, 'axis': 1}
 
-par5j = {'global_shape': (200, 201, 101),
+par3j = {'global_shape': (200, 201, 101),
          'partition': Partition.SCATTER,
          'dtype': np.complex128, 'axis': 2}
+
+par4 = {'x': np.random.normal(100, 100, (500, 501)),
+        'partition': Partition.SCATTER, 'axis': 1}
+
+par4j = {'x': np.random.normal(100, 100, (500, 501)) + 1.0j * np.random.normal(50, 50, (500, 501)),
+         'partition': Partition.SCATTER, 'axis': 1}
+
+par5 = {'x': np.random.normal(300, 300, (500, 501)),
+        'partition': Partition.SCATTER, 'axis': 1}
+
+par5j = {'x': np.random.normal(300, 300, (500, 501)) + 1.0j * np.random.normal(50, 50, (500, 501)),
+         'partition': Partition.SCATTER, 'axis': 1}
+
+par6 = {'x': np.random.normal(100, 100, (500, 500)),
+        'partition': Partition.SCATTER, 'axis': 0}
+
+par7 = {'x': np.random.normal(300, 300, (500, 500)),
+        'partition': Partition.SCATTER, 'axis': 0}
+
+par8 = {'x': np.random.normal(100, 100, (1000,)),
+        'partition': Partition.SCATTER, 'axis': 0}
+
+par9 = {'x': np.random.normal(300, 300, (1000,)),
+        'partition': Partition.SCATTER, 'axis': 0}
 
 
 @pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize("par", [(par1), (par1j), (par2),
-                                 (par2j), (par5), (par5j)])
+                                 (par2j), (par3), (par3j)])
 def test_creation(par):
     """Test creation of local arrays"""
     distributed_array = DistributedArray(global_shape=par['global_shape'],
@@ -83,7 +97,7 @@ def test_creation(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par3_1), (par3_2), (par4_1), (par4_2)])
+@pytest.mark.parametrize("par", [(par4), (par4j), (par5), (par5j)])
 def test_to_dist(par):
     """Test the ``to_dist`` method"""
     dist_array = DistributedArray.to_dist(x=par['x'],
@@ -95,7 +109,7 @@ def test_to_dist(par):
 
 
 @pytest.mark.mpi(minsize=2)
-@pytest.mark.parametrize("par1, par2", [(par3_1, par3_2), (par4_1, par4_2)])
+@pytest.mark.parametrize("par1, par2", [(par4, par5), (par4j, par5j)])
 def test_distributed_math(par1, par2):
     """Test the Element-Wise Addition, Subtraction and Multiplication"""
     arr1 = DistributedArray.to_dist(x=par1['x'], partition=par1['partition'])
@@ -118,23 +132,22 @@ def test_distributed_math(par1, par2):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par1, par2", [(par3_1, par3_2), (par4_1, par4_2)])
+@pytest.mark.parametrize("par1, par2", [(par6, par7), (par8, par9)])
 def test_distributed_dot(par1, par2):
     """Test Distributed Dot product"""
-    pass
+    arr1 = DistributedArray.to_dist(x=par1['x'], partition=par1['partition'], axis=par1['axis'])
+    arr2 = DistributedArray.to_dist(x=par2['x'], partition=par2['partition'], axis=par2['axis'])
+    assert_almost_equal(arr1.dot(arr2), np.dot(par1['x'].flatten(), par2['x'].flatten()), decimal=3)
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par3_1), (par3_2)])
+@pytest.mark.parametrize("par", [(par4), (par4j), (par5), (par5j),
+                                 (par6), (par7), (par8), (par9)])
 def test_distributed_norm(par):
-    """Test Distributed norm method"""
+    """Test Distributed numpy.linalg.norm method"""
     arr = DistributedArray.to_dist(x=par['x'], axis=par['axis'])
     assert_array_almost_equal(arr.norm(ord=1, axis=par['axis']),
                               np.linalg.norm(par['x'], ord=1, axis=par['axis']), decimal=3)
-    with pytest.raises(NotImplementedError):
-        arr.norm(ord=1, axis=0)
     assert_array_almost_equal(arr.norm(ord=np.inf, axis=par['axis']),
                               np.linalg.norm(par['x'], ord=np.inf, axis=par['axis']), decimal=3)
-    with pytest.raises(NotImplementedError):
-        arr.norm(ord=np.inf, axis=0)
     assert_almost_equal(arr.norm(), np.linalg.norm(par['x'].flatten()))

--- a/tests/test_distributedarray.py
+++ b/tests/test_distributedarray.py
@@ -4,7 +4,7 @@
 """
 import numpy as np
 import pytest
-from numpy.testing import assert_array_almost_equal, assert_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_almost_equal, assert_allclose
 
 from pylops_mpi import DistributedArray, Partition
 from pylops_mpi.DistributedArray import local_split
@@ -146,8 +146,8 @@ def test_distributed_dot(par1, par2):
 def test_distributed_norm(par):
     """Test Distributed numpy.linalg.norm method"""
     arr = DistributedArray.to_dist(x=par['x'], axis=par['axis'])
-    assert_array_almost_equal(arr.norm(ord=1, axis=par['axis']),
-                              np.linalg.norm(par['x'], ord=1, axis=par['axis']), decimal=3)
-    assert_array_almost_equal(arr.norm(ord=np.inf, axis=par['axis']),
-                              np.linalg.norm(par['x'], ord=np.inf, axis=par['axis']), decimal=3)
-    assert_almost_equal(arr.norm(), np.linalg.norm(par['x'].flatten()))
+    assert_allclose(arr.norm(ord=1, axis=par['axis']),
+                              np.linalg.norm(par['x'], ord=1, axis=par['axis']), rtol=1e-14)
+    assert_allclose(arr.norm(ord=np.inf, axis=par['axis']),
+                              np.linalg.norm(par['x'], ord=np.inf, axis=par['axis']), rtol=1e-14)
+    assert_allclose(arr.norm(), np.linalg.norm(par['x'].flatten()), rtol=1e-14)

--- a/tests/test_distributedarray.py
+++ b/tests/test_distributedarray.py
@@ -4,7 +4,7 @@
 """
 import numpy as np
 import pytest
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_almost_equal
 
 from pylops_mpi import DistributedArray, Partition
 from pylops_mpi.DistributedArray import local_split
@@ -125,7 +125,12 @@ def test_distributed_dot(par1, par2):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par1, par2", [(par3_1, par3_2), (par4_1, par4_2)])
-def test_distributed_norm(par1, par2):
+@pytest.mark.parametrize("par", [(par3_1), (par3_2)])
+def test_distributed_norm(par):
     """Test Distributed norm method"""
-    pass
+    arr = DistributedArray.to_dist(x=par['x'], axis=par['axis'])
+    assert_array_almost_equal(arr.norm(ord=1), np.linalg.norm(par['x'], ord=1, axis=par['axis']),
+                              decimal=3)
+    assert_array_almost_equal(arr.norm(ord=np.inf), np.linalg.norm(par['x'], ord=np.inf, axis=par['axis']),
+                              decimal=3)
+    assert_almost_equal(arr.norm(flatten=True), np.linalg.norm(par['x'].flatten()))


### PR DESCRIPTION
For #21 
- Added `_check_partition_shape` to check for same partition and local array shape.
- Added `_allreduce` to perform MPI reduction operation.
- Added `ndim` as a parameter.
- Added `_compute_vector_norm` to perform norm using local arrays along axis.
- Added Dot Product.
- Added Norm Method.
- Renamed par tests and add new tests for Dot and norm method to make it more clean.