### PR TITLE
Display gallery examples using mpi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PIP := $(shell command -v pip3 2> /dev/null || command which pip 2> /dev/null)
 PYTHON := $(shell command -v python3 2> /dev/null || command which python 2> /dev/null)
-NUM_PROCESSES = 5
+NUM_PROCESSES = 3
 
 .PHONY: install dev-install lint tests
 
@@ -45,3 +45,6 @@ docupdate:
 
 servedoc:
 	$(PYTHON) -m http.server --directory docs/build/
+
+run_examples:
+	cd examples && sh mpi_examples.sh $(NUM_PROCESSES) && cd ..

--- a/Makefile
+++ b/Makefile
@@ -46,5 +46,6 @@ docupdate:
 servedoc:
 	$(PYTHON) -m http.server --directory docs/build/
 
+# Run examples using mpi
 run_examples:
 	cd examples && sh mpi_examples.sh $(NUM_PROCESSES) && cd ..

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -7,3 +7,9 @@ Here is a collection of examples that demonstrate the usage of PyLops-MPI operat
     All examples are currently run on a single rank when building the documentation.
     However, we test their correctness off-line with multiple ranks and we encourage users to also
     run them with multiple ranks when learning about pylops-mpi.
+
+    Use the following command to run the gallery examples using MPI.
+
+    .. code-block:: shell-session
+
+       $ make run_examples

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -1,4 +1,9 @@
 ===============
 Gallery
 ===============
-Examples using pylops_mpi
+Here is a collection of examples that demonstrate the usage of PyLops-MPI operators and utilities.
+
+.. note::
+    All examples are currently run on a single rank when building the documentation.
+    However, we test their correctness off-line with multiple ranks and we encourage users to also
+    run them with multiple ranks when learning about pylops-mpi.

--- a/examples/mpi_examples.sh
+++ b/examples/mpi_examples.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Folder path containing example files
+folder_path="."
+
+# Number of mpi processes
+num_processes=$1
+
+if [ "$num_processes" -lt 2 ]; then
+  echo "Number of processes should be greater than or equal to 2, $num_processes < 2"
+else
+  for file in "$folder_path"/*.py; do
+      echo "Running $file with $num_processes processes"
+      mpiexec -n "$num_processes" python "$file"
+  done
+fi


### PR DESCRIPTION
Like we had discussed..
- Added the `note` to `examples/README.rst`
- Added mpi_examples.sh which runs all the files in the folder, one can run using `sh mpi_examples.sh <num_processes>`
- Also added `run_examples` in the `Makefile`.
- Also changed the `NUM_PROCESSES` in `Makefile` to 3 for quicker results..