### PR TITLE
Added MPILinearOperator and MPIBlockdiag

### DIFF
--- a/pylops_mpi/BlockDiag.py
+++ b/pylops_mpi/BlockDiag.py
@@ -1,8 +1,8 @@
 import numpy as np
 from mpi4py import MPI
-from typing import Optional, Union
+from typing import Optional
 
-from pylops.utils import DTypeLike, NDArray
+from pylops.utils import DTypeLike
 from pylops_mpi import MPILinearOperator, DistributedArray
 from pylops_mpi.LinearOperator import asmpilinearoperator
 from pylops_mpi.DistributedArray import local_split, Partition

--- a/pylops_mpi/BlockDiag.py
+++ b/pylops_mpi/BlockDiag.py
@@ -1,0 +1,65 @@
+import numpy as np
+from mpi4py import MPI
+from typing import Optional, Union
+
+from pylops.utils import DTypeLike, NDArray
+from pylops_mpi import MPILinearOperator, DistributedArray
+from pylops_mpi.LinearOperator import asmpilinearoperator
+from pylops_mpi.DistributedArray import local_split, Partition
+
+from scipy.sparse.linalg._interface import _get_dtype
+
+
+class MPIBlockDiag(MPILinearOperator):
+
+    def __init__(self, ops, base_comm: MPI.Comm = MPI.COMM_WORLD, dtype: Optional[DTypeLike] = None):
+        self.ops = self._assign_ops(ops, base_comm)
+        self.kind = "mix"
+        mops = np.zeros(len(self.ops), dtype=np.int64)
+        nops = np.zeros(len(self.ops), dtype=np.int64)
+        for iop, oper in enumerate(self.ops):
+            nops[iop] = oper.shape[0]
+            mops[iop] = oper.shape[1]
+        self.mops = base_comm.allgather((mops.sum(), ))
+        self.nops = base_comm.allgather((nops.sum(), ))
+        self.nnops = np.insert(np.cumsum(nops), 0, 0)
+        self.mmops = np.insert(np.cumsum(mops), 0, 0)
+        self.shape = (np.sum(self.nops), np.sum(self.mops))
+        if dtype:
+            self.dtype = _get_dtype(dtype)
+        else:
+            self.dtype = np.dtype(dtype)
+        super().__init__(shape=self.shape, dtype=self.dtype, base_comm=base_comm, kind=self.kind)
+
+    @staticmethod
+    def _assign_ops(ops, base_comm):
+        local_shapes = local_split((len(ops),), base_comm, Partition.SCATTER, 0)
+        x = np.insert(np.cumsum(base_comm.allgather(local_shapes)), 0, 0)
+        return ops[x[base_comm.Get_rank()]:x[base_comm.Get_rank() + 1]]
+
+    def _matvec(self, x: Union[NDArray, DistributedArray]):
+        y = DistributedArray(global_shape=self.shape[0], local_shapes=self.nops)
+        if not isinstance(x, DistributedArray):
+            x = DistributedArray.to_dist(x=x, local_shapes=self.mops)
+        y1 = []
+        for iop, oper in enumerate(self.ops):
+            if not isinstance(oper, MPILinearOperator):
+                oper = asmpilinearoperator(Op=oper)
+            y1.append(oper.matvec(x.local_array[self.mmops[iop]: self.mmops[iop+1]]))
+        if y1:
+            y[:] = np.concatenate(y1)
+        return y
+
+    def _rmatvec(self, x: Union[NDArray, DistributedArray]):
+        y = DistributedArray(global_shape=self.shape[1], local_shapes=self.mops)
+        if not isinstance(x, DistributedArray):
+            x = DistributedArray.to_dist(x=x, local_shapes=self.nops)
+        y1 = []
+        for iop, oper in enumerate(self.ops):
+            if not isinstance(oper, MPILinearOperator):
+                oper = asmpilinearoperator(Op=oper)
+            y1.append(oper.rmatvec(x.local_array[self.nnops[iop]: self.nnops[iop + 1]]))
+        if y1:
+            y[:] = np.concatenate(y1)
+        return y
+

--- a/pylops_mpi/LinearOperator.py
+++ b/pylops_mpi/LinearOperator.py
@@ -161,12 +161,12 @@ class _TransposedLinearOperator(MPILinearOperator):
     def _matvec(self, x):
         arr = DistributedArray.to_dist(x=self.A.rmatvec(np.conj(x)))
         arr[:] = np.conj(arr.local_array)
-        return arr.asarray()
+        return arr
 
     def _rmatvec(self, x):
         arr = DistributedArray.to_dist(x=self.A.matvec(np.conj(x)))
         arr[:] = np.conj(arr.local_array)
-        return arr.asarray()
+        return arr
 
 
 class _ProductLinearOperator(MPILinearOperator):
@@ -217,13 +217,13 @@ class _ScaledLinearOperator(MPILinearOperator):
         y = DistributedArray.to_dist(self.args[0].matvec(x))
         if y is not None:
             y[:] *= self.args[1]
-        return y.asarray()
+        return y
 
     def _rmatvec(self, x):
         y = DistributedArray.to_dist(x=self.args[0].rmatvec(x))
         if y is not None:
             y[:] *= np.conj(self.args[1])
-        return y.asarray()
+        return y
 
     def _adjoint(self):
         A, alpha = self.args
@@ -253,12 +253,12 @@ class _SumLinearOperator(MPILinearOperator):
     def _matvec(self, x):
         arr1 = DistributedArray.to_dist(x=self.args[0].matvec(x))
         arr2 = DistributedArray.to_dist(x=self.args[1].matvec(x))
-        return (arr1 + arr2).asarray()
+        return arr1 + arr2
 
     def _rmatvec(self, x):
         arr1 = DistributedArray.to_dist(x=self.args[0].rmatvec(x))
         arr2 = DistributedArray.to_dist(x=self.args[1].rmatvec(x))
-        return (arr1 + arr2).asarray()
+        return arr1 + arr2
 
     def _adjoint(self):
         A, B = self.args
@@ -311,13 +311,13 @@ class _ConjLinearOperator(MPILinearOperator):
         y = DistributedArray.to_dist(x=self.A.matvec(x.conj()))
         if y is not None:
             y[:] = y.local_array.conj()
-        return y.asarray()
+        return y
 
     def _rmatvec(self, x):
         y = DistributedArray.to_dist(x=self.A.rmatvec(x.conj()))
         if y is not None:
             y[:] = y.local_array.conj()
-        return y.asarray()
+        return y
 
     def _adjoint(self):
         return _ConjLinearOperator(self.A.H)

--- a/pylops_mpi/LinearOperator.py
+++ b/pylops_mpi/LinearOperator.py
@@ -42,9 +42,9 @@ class MPILinearOperator(LinearOperator):
                 y = self._matvec(x)
         elif self.kind == 'master':
             if self.Op:
-                y = self.Op._matvec(x)
+                y = self.Op._matvec(x) if self.rank == 0 else None
             else:
-                y = self._matvec(x)
+                y = self._matvec(x) if self.rank == 0 else None
         else:
             raise KeyError('kind must be all, master, mix or force')
         if isinstance(y, DistributedArray):
@@ -61,10 +61,10 @@ class MPILinearOperator(LinearOperator):
             else:
                 y = self._rmatvec(x)
         elif self.kind == 'master':
-            if self.rank == 0:
-                y = self._rmatvec(x)
+            if self.Op:
+                y = self.Op._rmatvec(x) if self.rank == 0 else None
             else:
-                y = None
+                y = self._rmatvec(x) if self.rank == 0 else None
         else:
             raise KeyError('kind must be all, master, mix or force')
         if isinstance(y, DistributedArray):
@@ -83,7 +83,6 @@ class MPILinearOperator(LinearOperator):
             if x is None or x.ndim == 1:
                 return self.matvec(x)
             elif x.ndim == 2:
-                # x = DistributedArray.to_dist(x=x)
                 return self.matmat(x)
             else:
                 raise ValueError('expected 1-d or 2-d array or matrix, got %r'

--- a/pylops_mpi/LinearOperator.py
+++ b/pylops_mpi/LinearOperator.py
@@ -1,0 +1,306 @@
+import numpy as np
+from mpi4py import MPI
+from typing import Callable
+
+from scipy.sparse.linalg._interface import _get_dtype
+from scipy.sparse._sputils import isintlike
+from pylops import LinearOperator
+from pylops.utils import DTypeLike, ShapeLike
+
+from pylops_mpi import DistributedArray
+
+
+class MPILinearOperator(LinearOperator):
+    def __init__(self, shape: ShapeLike, dtype: DTypeLike, Op: LinearOperator = None, kind='all',
+                 explicit=False, base_comm: MPI.Comm = MPI.COMM_WORLD):
+        self.Op = Op
+        self.kind = kind
+        self.dtype = dtype
+        self.shape = shape
+        self.base_comm = base_comm
+        self.size = self.base_comm.Get_size()
+        self.rank = self.base_comm.Get_rank()
+        super().__init__(Op=Op, explicit=explicit)
+
+    def matvec(self, x):
+        if self.kind in ("all", "force", "mix"):
+            if self.Op:
+                y = self.Op._matvec(x)
+            else:
+                y = self._matvec(x)
+                if isinstance(y, DistributedArray):
+                    y = y.asarray()
+        elif self.kind == 'master':
+            if self.rank == 0:
+                y = self._matvec(x)
+            else:
+                y = None
+        else:
+            raise KeyError('kind must be all, master, mix or force')
+        return y
+
+    def rmatvec(self, x):
+        if self.kind in ('all', 'mix', 'force'):
+            if self.Op:
+                y = self.Op._rmatvec(x)
+            else:
+                y = self._rmatvec(x)
+                if isinstance(y, DistributedArray):
+                    y = y.asarray()
+        elif self.kind == 'master':
+            if self.rank == 0:
+                y = self._rmatvec(x)
+            else:
+                y = None
+        else:
+            raise KeyError('kind must be all, master, mix or force')
+        return y
+
+    def dot(self, x):
+        if isinstance(x, MPILinearOperator):
+            Op = _ProductLinearOperator(self, x)
+            Op.clinear = (getattr(self, 'clinear', True)
+                          and getattr(x, 'clinear', True))
+            return Op
+        elif np.isscalar(x):
+            return _ScaledLinearOperator(self, x)
+        else:
+            if x is None or x.ndim == 1:
+                return self.matvec(x)
+            elif x.ndim == 2:
+                # x = DistributedArray.to_dist(x=x)
+                return self.matmat(x)
+            else:
+                raise ValueError('expected 1-d or 2-d array or matrix, got %r'
+                                 % x)
+
+    def adjoint(self):
+        return self._adjoint()
+
+    H = property(adjoint)
+
+    def transpose(self):
+        return self._transpose()
+
+    T = property(transpose)
+
+    def __mul__(self, x):
+        return self.dot(x)
+
+    def __rmul__(self, x):
+        if np.isscalar(x):
+            return _ScaledLinearOperator(self, x)
+        else:
+            return NotImplemented
+
+    def __pow__(self, p):
+        return _PowerLinearOperator(self, p)
+
+    def __add__(self, x):
+        return _SumLinearOperator(self, x)
+
+    def __neg__(self):
+        return _ScaledLinearOperator(self, -1)
+
+    def __sub__(self, x):
+        return self.__add__(-x)
+
+    def _adjoint(self):
+        return _AdjointLinearOperator(self)
+
+    def _transpose(self):
+        return _TransposedLinearOperator(self)
+
+    def conj(self):
+        return _ConjLinearOperator(self)
+
+
+class _AdjointLinearOperator(MPILinearOperator):
+    """Adjoint of arbitrary MPI Linear Operator"""
+
+    def __init__(self, A: MPILinearOperator):
+        self.A = A
+        self.kind = A.kind
+        self.args = (A,)
+        super().__init__(shape=(A.shape[1], A.shape[0]), dtype=A.dtype,
+                         explicit=A.explicit, base_comm=MPI.COMM_WORLD,
+                         kind=self.kind)
+
+    def _matvec(self, x):
+        return self.A.rmatvec(x)
+
+    def _rmatvec(self, x):
+        return self.A.matvec(x)
+
+
+class _TransposedLinearOperator(MPILinearOperator):
+    """Transposition of arbitrary MPI Linear Operator"""
+
+    def __init__(self, A: MPILinearOperator):
+        self.A = A
+        self.kind = A.kind
+        self.args = (A,)
+        super().__init__(shape=(A.shape[1], A.shape[0]), dtype=A.dtype,
+                         explicit=A.explicit, base_comm=MPI.COMM_WORLD,
+                         kind=self.kind)
+
+    def _matvec(self, x):
+        arr = DistributedArray.to_dist(x=self.A.rmatvec(np.conj(x)))
+        arr[:] = np.conj(arr.local_array)
+        return arr.asarray()
+
+    def _rmatvec(self, x):
+        arr = DistributedArray.to_dist(x=self.A.matvec(np.conj(x)))
+        arr[:] = np.conj(arr.local_array)
+        return arr.asarray()
+
+
+class _ProductLinearOperator(MPILinearOperator):
+    """Product MPI Linear Operator
+    """
+    def __init__(self, A: MPILinearOperator, B: MPILinearOperator):
+        if not isinstance(A, MPILinearOperator) or not isinstance(B, MPILinearOperator):
+            raise ValueError('both operands have to be a LinearOperator')
+        if A.shape[1] != B.shape[0]:
+            raise ValueError('cannot multiply %r and %r: shape mismatch' % (A, B))
+        self.args = (A, B)
+        self.kind = 'mix'
+        super().__init__(shape=(A.shape[0], B.shape[1]), dtype=_get_dtype([A, B]),
+                         explicit=A.explicit, base_comm=MPI.COMM_WORLD, kind=self.kind)
+
+    def _matvec(self, x):
+        return self.args[0].matvec(self.args[1].matvec(x))
+
+    def _rmatvec(self, x):
+        return self.args[1].rmatvec(self.args[0].rmatvec(x))
+
+    def _adjoint(self):
+        A, B = self.args
+        return B.H * A.H
+
+
+class _ScaledLinearOperator(MPILinearOperator):
+    """Scaled MPI Linear Operator
+    """
+
+    def __init__(self, A: MPILinearOperator, alpha):
+        if not isinstance(A, MPILinearOperator):
+            raise ValueError('MPILinearOperator expected as A')
+        if not np.isscalar(alpha):
+            raise ValueError('scalar expected as alpha')
+        self.args = (A, alpha)
+        self.kind = A.kind
+        super().__init__(shape=A.shape, dtype=_get_dtype([A], [type(alpha)]),
+                         explicit=A.explicit, base_comm=MPI.COMM_WORLD, kind=self.kind)
+
+    def _matvec(self, x):
+        y = DistributedArray.to_dist(self.args[0].matvec(x))
+        if y is not None:
+            y[:] *= self.args[1]
+        return y.asarray()
+
+    def _rmatvec(self, x):
+        y = DistributedArray.to_dist(x=self.args[0].rmatvec(x))
+        if y is not None:
+            y[:] *= np.conj(self.args[1])
+        return y.asarray()
+
+    def _adjoint(self):
+        A, alpha = self.args
+        return A.H * np.conj(alpha)
+
+
+class _SumLinearOperator(MPILinearOperator):
+    """Sum of MPI LinearOperators
+    """
+
+    def __init__(self, A: MPILinearOperator, B: MPILinearOperator):
+        if not isinstance(A, MPILinearOperator) or not isinstance(B, MPILinearOperator):
+            raise ValueError('both operands have to be a MPILinearOperator')
+        if A.shape != B.shape:
+            raise ValueError("cannot add %r and %r: shape mismatch" % (A, B))
+        self.args = (A, B)
+        self.kind = 'mix'
+        super().__init__(shape=A.shape, dtype=A.dtype, explicit=A.explicit,
+                         base_comm=MPI.COMM_WORLD, kind=self.kind)
+
+    def _matvec(self, x):
+        arr1 = DistributedArray.to_dist(x=self.args[0].matvec(x))
+        arr2 = DistributedArray.to_dist(x=self.args[1].matvec(x))
+        return (arr1 + arr2).asarray()
+
+    def _rmatvec(self, x):
+        arr1 = DistributedArray.to_dist(x=self.args[0].rmatvec(x))
+        arr2 = DistributedArray.to_dist(x=self.args[1].rmatvec(x))
+        return (arr1 + arr2).asarray()
+
+    def _adjoint(self):
+        A, B = self.args
+        return A.H + B.H
+
+
+class _PowerLinearOperator(MPILinearOperator):
+    """Power of MPI Linear Operator
+    """
+
+    def __init__(self, A: MPILinearOperator, p: int) -> None:
+        if not isinstance(A, MPILinearOperator):
+            raise ValueError("LinearOperator expected as A")
+        if A.shape[0] != A.shape[1]:
+            raise ValueError("square LinearOperator expected, got %r" % A)
+        if not isintlike(p) or p < 0:
+            raise ValueError("non-negative integer expected as p")
+
+        super(_PowerLinearOperator, self).__init__(shape=A.shape, dtype=A.dtype, kind=A.kind,
+                                                   explicit=A.explicit, base_comm=A.base_comm)
+        self.args = (A, p)
+
+    def _power(self, fun: Callable, x):
+        res = np.array(x, copy=True)
+        for _ in range(self.args[1]):
+            res = fun(res)
+        return res
+
+    def _matvec(self, x):
+        return self._power(self.args[0].matvec, x)
+
+    def _rmatvec(self, x):
+        return self._power(self.args[0].rmatvec, x)
+
+
+class _ConjLinearOperator(MPILinearOperator):
+    """Complex conjugate linear operator
+    """
+
+    def __init__(self, A: MPILinearOperator):
+        if not isinstance(A, MPILinearOperator):
+            raise TypeError('A must be a MPILinearOperator')
+        self.kind = A.kind
+        self.A = A
+        super().__init__(shape=A.shape, dtype=A.dtype,
+                         explicit=A.explicit, base_comm=MPI.COMM_WORLD,
+                         kind=self.kind)
+
+    def _matvec(self, x):
+        y = DistributedArray.to_dist(x=self.A.matvec(x.conj()))
+        if y is not None:
+            y[:] = y.conj()
+        return y.asarray()
+
+    def _rmatvec(self, x):
+        y = DistributedArray.to_dist(x=self.A.rmatvec(x.conj()))
+        if y is not None:
+            y[:] = y.conj()
+        return y.asarray()
+
+    def _adjoint(self):
+        return _ConjLinearOperator(self.A.H)
+
+
+def asmpilinearoperator(Op, kind: str = "all"):
+    if isinstance(Op, MPILinearOperator):
+        return Op
+    else:
+        return MPILinearOperator(shape=Op.shape, dtype=Op.dtype, Op=Op,
+                                 explicit=Op.explicit, base_comm=MPI.COMM_WORLD,
+                                 kind=kind)

--- a/pylops_mpi/MatrixMult.py
+++ b/pylops_mpi/MatrixMult.py
@@ -12,7 +12,7 @@ from pylops_mpi import MPILinearOperator, DistributedArray, Partition
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
-class MatrixMult(MPILinearOperator):
+class MPIMatrixMult(MPILinearOperator):
     def __init__(
             self,
             A: NDArray,

--- a/pylops_mpi/MatrixMult.py
+++ b/pylops_mpi/MatrixMult.py
@@ -1,0 +1,80 @@
+import numpy as np
+import logging
+from typing import Optional, Union
+
+from mpi4py import MPI
+
+from pylops.utils import NDArray, DTypeLike, InputDimsLike
+from pylops.utils._internal import _value_or_sized_to_array
+
+from pylops_mpi import MPILinearOperator, DistributedArray, Partition
+
+logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
+
+
+class MatrixMult(MPILinearOperator):
+    def __init__(
+            self,
+            A: NDArray,
+            otherdims: Optional[Union[int, InputDimsLike]] = None,
+            dtype: DTypeLike = "float64",
+            base_comm: MPI.Comm = MPI.COMM_WORLD,
+            kind: str = "all"
+    ) -> None:
+        self.A = A
+        if isinstance(A, np.ndarray):
+            self.complex = np.iscomplexobj(A)
+        else:
+            self.complex = np.iscomplexobj(A.data)
+        if otherdims is None:
+            dims, dimsd = (A.shape[1],), (A.shape[0],)
+            self.reshape = False
+            explicit = True
+        else:
+            otherdims = _value_or_sized_to_array(otherdims)
+            self.otherdims = np.array(otherdims, dtype=int)
+            dims, dimsd = np.insert(self.otherdims, 0, self.A.shape[1]), np.insert(
+                self.otherdims, 0, self.A.shape[0]
+            )
+            self.dimsflatten, self.dimsdflatten = np.insert(
+                [np.prod(self.otherdims)], 0, self.A.shape[1]
+            ), np.insert([np.prod(self.otherdims)], 0, self.A.shape[0])
+            self.reshape = True
+            explicit = False
+        self.shape = dimsd + dims
+        # Check dtype for correctness (upcast to complex when A is complex)
+        if np.iscomplexobj(A) and not np.iscomplexobj(np.ones(1, dtype=dtype)):
+            dtype = A.dtype
+            logging.warning("Matrix A is a complex object, dtype cast to %s" % dtype)
+        super().__init__(
+            dtype=np.dtype(dtype), shape=self.shape, base_comm=base_comm, kind=kind, explicit=explicit,
+        )
+
+    def _matvec(self, x):
+        if self.kind in ("all", "force"):
+            # To handle dot product
+            x = DistributedArray.to_dist(x=x, partition=Partition.BROADCAST).local_array
+        if self.reshape:
+            x = np.reshape(x, self.dimsflatten)
+        y = self.A.dot(x)
+        if self.reshape:
+            y = y.ravel()
+        if self.kind == "master":
+            return y
+        return np.concatenate(self.base_comm.allgather(y))
+
+    def _rmatvec(self, x):
+        if self.kind in ("all", "force"):
+            # To handle dot product
+            x = DistributedArray.to_dist(x=x).local_array
+        if self.reshape:
+            x = np.reshape(x, self.dimsflatten)
+        if self.complex:
+            y = (self.A.T.dot(x.conj())).conj()
+        else:
+            y = self.A.T.dot(x)
+        if self.reshape:
+            return y.ravel()
+        if self.kind == "master":
+            return y
+        return self.base_comm.allreduce(y)

--- a/pylops_mpi/__init__.py
+++ b/pylops_mpi/__init__.py
@@ -1,6 +1,6 @@
 from .DistributedArray import DistributedArray, Partition
 from .LinearOperator import MPILinearOperator, asmpilinearoperator
-from .MatrixMult import MatrixMult
+from .MatrixMult import MPIMatrixMult
 from .BlockDiag import MPIBlockDiag
 from .plotting.plotting import *
 

--- a/pylops_mpi/__init__.py
+++ b/pylops_mpi/__init__.py
@@ -1,4 +1,6 @@
 from .DistributedArray import DistributedArray, Partition
+from .LinearOperator import MPILinearOperator, asmpilinearoperator
+from .BlockDiag import MPIBlockDiag
 from .plotting.plotting import *
 
 try:

--- a/pylops_mpi/__init__.py
+++ b/pylops_mpi/__init__.py
@@ -1,5 +1,6 @@
 from .DistributedArray import DistributedArray, Partition
 from .LinearOperator import MPILinearOperator, asmpilinearoperator
+from .MatrixMult import MatrixMult
 from .BlockDiag import MPIBlockDiag
 from .plotting.plotting import *
 

--- a/tests/test_blockdiag.py
+++ b/tests/test_blockdiag.py
@@ -26,5 +26,6 @@ def test_blockdiag(par):
     block_diag = pylops.BlockDiag(ops=ops)
     x = np.random.normal(100, 100, (block_diag.shape[1], ))
     y = np.random.normal(100, 100, (block_diag.shape[0], ))
+    assert mpi_block_diag.shape == block_diag.shape
     assert_allclose(mpi_block_diag * x, block_diag * x, rtol=1e-14)
     assert_allclose(mpi_block_diag.H * y, block_diag.H * y, rtol=1e-14)

--- a/tests/test_blockdiag.py
+++ b/tests/test_blockdiag.py
@@ -22,11 +22,11 @@ def test_blockdiag(par):
     ops = [pylops.Identity(par['ny'], par['nx']),
            pylops.Zero(par['ny'], par['nx']), pylops.MatrixMult(G1),
            pylops.MatrixMult(G2)]
-    mpi_block_diag = pylops_mpi.MPIBlockDiag(ops=ops)
-    assert isinstance(mpi_block_diag, MPILinearOperator)
-    block_diag = pylops.BlockDiag(ops=ops)
-    x = np.random.normal(100, 100, (block_diag.shape[1],))
-    y = np.random.normal(100, 100, (block_diag.shape[0],))
-    assert mpi_block_diag.shape == block_diag.shape
-    assert_allclose(mpi_block_diag * x, block_diag * x, rtol=1e-12)
-    assert_allclose(mpi_block_diag.H * y, block_diag.H * y, rtol=1e-12)
+    BDiag_MPI = pylops_mpi.MPIBlockDiag(ops=ops)
+    assert isinstance(BDiag_MPI, MPILinearOperator)
+    BDiag = pylops.BlockDiag(ops=ops)
+    x = np.random.normal(100, 100, (BDiag.shape[1],))
+    y = np.random.normal(100, 100, (BDiag.shape[0],))
+    assert BDiag_MPI.shape == BDiag.shape
+    assert_allclose(BDiag_MPI * x, BDiag * x, rtol=1e-12)
+    assert_allclose(BDiag_MPI.H * y, BDiag.H * y, rtol=1e-12)

--- a/tests/test_blockdiag.py
+++ b/tests/test_blockdiag.py
@@ -1,0 +1,30 @@
+import numpy as np
+from numpy.testing import assert_allclose
+np.random.seed(42)
+import pytest
+
+import pylops
+from pylops_mpi import MPIBlockDiag, MPILinearOperator
+
+
+par1 = {'ny': 101, 'nx': 101, 'dtype': np.float64}
+par2 = {'ny': 101, 'nx': 101, 'dtype': np.float64}
+par3 = {'ny': 301, 'nx': 101, 'dtype': np.float64}
+par4 = {'ny': 301, 'nx': 101, 'dtype': np.float64}
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
+def test_blockdiag(par):
+    G1 = np.random.normal(0, 10, (par['ny'], par['nx'])).astype(par['dtype'])
+    G2 = np.random.normal(0, 10, (par['ny'], par['nx'])).astype(par['dtype'])
+    ops = [pylops.Identity(par['ny'], par['nx']),
+           pylops.Zero(par['ny'], par['nx']), pylops.MatrixMult(G1),
+           pylops.MatrixMult(G2)]
+    mpi_block_diag = MPIBlockDiag(ops=ops)
+    assert isinstance(mpi_block_diag, MPILinearOperator)
+    block_diag = pylops.BlockDiag(ops=ops)
+    x = np.random.normal(100, 100, (block_diag.shape[1], ))
+    y = np.random.normal(100, 100, (block_diag.shape[0], ))
+    assert_allclose(mpi_block_diag * x, block_diag * x, rtol=1e-14)
+    assert_allclose(mpi_block_diag.H * y, block_diag.H * y, rtol=1e-14)

--- a/tests/test_blockdiag.py
+++ b/tests/test_blockdiag.py
@@ -1,11 +1,12 @@
 import numpy as np
 from numpy.testing import assert_allclose
+
 np.random.seed(42)
 import pytest
 
 import pylops
-from pylops_mpi import MPIBlockDiag, MPILinearOperator
-
+import pylops_mpi
+from pylops_mpi import MPILinearOperator
 
 par1 = {'ny': 101, 'nx': 101, 'dtype': np.float64}
 par2 = {'ny': 101, 'nx': 101, 'dtype': np.float64}
@@ -21,11 +22,11 @@ def test_blockdiag(par):
     ops = [pylops.Identity(par['ny'], par['nx']),
            pylops.Zero(par['ny'], par['nx']), pylops.MatrixMult(G1),
            pylops.MatrixMult(G2)]
-    mpi_block_diag = MPIBlockDiag(ops=ops)
+    mpi_block_diag = pylops_mpi.MPIBlockDiag(ops=ops)
     assert isinstance(mpi_block_diag, MPILinearOperator)
     block_diag = pylops.BlockDiag(ops=ops)
-    x = np.random.normal(100, 100, (block_diag.shape[1], ))
-    y = np.random.normal(100, 100, (block_diag.shape[0], ))
+    x = np.random.normal(100, 100, (block_diag.shape[1],))
+    y = np.random.normal(100, 100, (block_diag.shape[0],))
     assert mpi_block_diag.shape == block_diag.shape
-    assert_allclose(mpi_block_diag * x, block_diag * x, rtol=1e-14)
-    assert_allclose(mpi_block_diag.H * y, block_diag.H * y, rtol=1e-14)
+    assert_allclose(mpi_block_diag * x, block_diag * x, rtol=1e-12)
+    assert_allclose(mpi_block_diag.H * y, block_diag.H * y, rtol=1e-12)

--- a/tests/test_linearoperator.py
+++ b/tests/test_linearoperator.py
@@ -53,7 +53,7 @@ def test_scaledop(par):
     SSop = Mop * -7
 
     A = DistributedArray.to_dist(x=A)
-    Mop = pylops_mpi.MatrixMult(A=A.local_array)
+    Mop = pylops_mpi.MPIMatrixMult(A=A.local_array)
     Sop_MPI = Mop * 5
     SSop_MPI = Mop * -7
 
@@ -73,7 +73,7 @@ def test_conj(par):
     Cop = Mop.conj()
 
     A = DistributedArray.to_dist(x=A)
-    Mop = pylops_mpi.MatrixMult(A=A.local_array)
+    Mop = pylops_mpi.MPIMatrixMult(A=A.local_array)
     Cop_MPI = Mop.conj()
 
     x = np.arange(par['nx'])

--- a/tests/test_linearoperator.py
+++ b/tests/test_linearoperator.py
@@ -1,0 +1,115 @@
+import numpy as np
+from numpy.testing import assert_allclose
+
+np.random.seed(42)
+import pytest
+
+import pylops
+from pylops_mpi import asmpilinearoperator, DistributedArray, MPILinearOperator
+
+par1 = {"ny": 11, "nx": 11, "dtype": np.float64}  # square real
+par2 = {"ny": 21, "nx": 11, "dtype": np.float64}  # overdetermined real
+par1j = {"ny": 11, "nx": 11, "dtype": np.float64}  # square imag
+par2j = {"ny": 21, "nx": 11, "dtype": np.float64}  # overdetermined imag
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
+def test_linearop(par):
+    # for kind = "all"
+    diag = DistributedArray.to_dist(x=np.arange(par['nx'] + par['ny']))
+    Dop = pylops.Diagonal(diag.local_array, dtype=par["dtype"])
+    Dop_MPI_1 = asmpilinearoperator(Op=Dop, kind="all")
+
+    # for kind = "master"
+    diag = np.arange(par['nx'] + par['ny'])
+    Dop = pylops.Diagonal(diag, dtype=par['dtype'])
+    Dop_MPI_2 = asmpilinearoperator(Op=Dop, kind="master")
+
+    assert isinstance(Dop_MPI_1, MPILinearOperator)
+    assert isinstance(Dop_MPI_2, MPILinearOperator)
+
+    assert isinstance(Dop_MPI_1.T, MPILinearOperator)
+    assert isinstance(Dop_MPI_2.T, MPILinearOperator)
+
+    assert isinstance(Dop_MPI_1.H, MPILinearOperator)
+    assert isinstance(Dop_MPI_2.H, MPILinearOperator)
+
+    assert isinstance(Dop_MPI_1.conj(), MPILinearOperator)
+    assert isinstance(Dop_MPI_2.conj(), MPILinearOperator)
+
+    assert isinstance(Dop_MPI_1 + Dop_MPI_2, MPILinearOperator)
+
+    assert isinstance(Dop_MPI_2 * Dop_MPI_1, MPILinearOperator)
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
+def test_scaledop(par):
+    diag = np.arange(par['nx'] + par['ny'])
+    Dop = pylops.Diagonal(diag=diag)
+    Sop = Dop * 5
+
+    diag = DistributedArray.to_dist(x=diag)
+    Dop = asmpilinearoperator(pylops.Diagonal(diag=diag.local_array))
+    Sop_MPI = Dop * 5
+
+    x = np.arange(par['nx'] + par['ny'])
+    assert_allclose(Sop_MPI * x, Sop * x, rtol=1e-14)
+    assert_allclose(Sop_MPI.H * x, Sop.H * x, rtol=1e-14)
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
+def test_conj(par):
+    diag = np.arange(par['nx'] + par['ny'])
+    Dop = pylops.Diagonal(diag=diag)
+    Cop = Dop.conj()
+
+    diag = DistributedArray.to_dist(x=diag)
+    Dop = asmpilinearoperator(pylops.Diagonal(diag=diag.local_array))
+    Cop_MPI = Dop.conj()
+
+    x = np.arange(par['nx'] + par['ny'])
+    assert_allclose(Cop_MPI * x, Cop * x, rtol=1e-14)
+    assert_allclose(Cop_MPI.H * x, Cop.H * x, rtol=1e-14)
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
+def test_power(par):
+    diag = np.arange(par['nx'] + par['ny'])
+    Dop = pylops.Diagonal(diag=diag)
+    Pop = Dop ** 2
+
+    diag = DistributedArray.to_dist(x=diag)
+    Dop = asmpilinearoperator(pylops.Diagonal(diag=diag.local_array))
+    Pop_MPI = Dop ** 2
+
+    x = np.arange(par['nx'] + par['ny'])
+    assert_allclose(Pop_MPI * x, Pop * x, rtol=1e-14)
+    assert_allclose(Pop_MPI.H * x, Pop.H * x, rtol=1e-14)
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
+def test_sum_prod(par):
+    diag = np.arange(par['nx'] + par['ny'])
+    Dop = pylops.Diagonal(diag=diag)
+    DDop = pylops.Diagonal(diag=2 * diag)
+
+    Sop = Dop + DDop
+    Mop = Dop * DDop
+
+    diag = DistributedArray.to_dist(x=diag)
+    Dop = asmpilinearoperator(pylops.Diagonal(diag=diag.local_array))
+    DDop = asmpilinearoperator(pylops.Diagonal(diag=2 * diag.local_array))
+
+    Sop_MPI = Dop + DDop
+    Mop_MPI = Dop * DDop
+
+    x = np.arange(par['nx'] + par['ny'])
+    assert_allclose(Sop_MPI * x, Sop * x, rtol=1e-14)
+    assert_allclose(Sop_MPI.H * x, Sop.H * x, rtol=1e-14)
+    assert_allclose(Mop_MPI * x, Mop * x, rtol=1e-14)
+    assert_allclose(Mop_MPI.H * x, Mop.H * x, rtol=1e-14)

--- a/tests/test_matrixmult.py
+++ b/tests/test_matrixmult.py
@@ -5,7 +5,7 @@ np.random.seed(42)
 import pytest
 
 import pylops
-from pylops_mpi import MatrixMult, DistributedArray
+from pylops_mpi import MPIMatrixMult, DistributedArray
 
 par1 = {"ny": 11, "nx": 11, "dtype": np.float64}
 par2 = {"ny": 21, "nx": 11, "dtype": np.float64}
@@ -21,10 +21,10 @@ def test_matmult(par):
 
     # kind="all"
     arr = DistributedArray.to_dist(x=A)
-    Mop_all = MatrixMult(A=arr.local_array, kind="all")
+    Mop_all = MPIMatrixMult(A=arr.local_array, kind="all")
 
     # kind="master"
-    Mop_master = MatrixMult(A=A, kind="master")
+    Mop_master = MPIMatrixMult(A=A, kind="master")
 
     x = np.arange(par['ny'])
     y = np.arange(par['nx'])

--- a/tests/test_matrixmult.py
+++ b/tests/test_matrixmult.py
@@ -1,0 +1,38 @@
+import numpy as np
+from numpy.testing import assert_allclose
+
+np.random.seed(42)
+import pytest
+
+import pylops
+from pylops_mpi import MatrixMult, DistributedArray
+
+par1 = {"ny": 11, "nx": 11, "dtype": np.float64}
+par2 = {"ny": 21, "nx": 11, "dtype": np.float64}
+par1j = {"ny": 11, "nx": 11, "dtype": np.float64}
+par2j = {"ny": 21, "nx": 11, "dtype": np.float64}
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
+def test_matmult(par):
+    A = np.random.normal(1, 10, (par['nx'], par['ny']))
+    Mop = pylops.MatrixMult(A=A)
+
+    # kind="all"
+    arr = DistributedArray.to_dist(x=A)
+    Mop_all = MatrixMult(A=arr.local_array, kind="all")
+
+    # kind="master"
+    Mop_master = MatrixMult(A=A, kind="master")
+
+    x = np.arange(par['ny'])
+    y = np.arange(par['nx'])
+    if Mop_master.rank == 0:
+        assert_allclose(Mop_all * x, Mop * x, rtol=1e-12)
+        assert_allclose(Mop_master * x, Mop * x, rtol=1e-12)
+        assert_allclose(Mop_all.H * y, Mop.H * y, rtol=1e-12)
+        assert_allclose(Mop_master.H * y, Mop.H * y, rtol=1e-12)
+    else:
+        assert_allclose(Mop_all * x, Mop * x, rtol=1e-12)
+        assert_allclose(Mop_all.H * y, Mop.H * y, rtol=1e-12)


### PR DESCRIPTION
- Added `local_shapes` as a parameter in the DistributedArray to force ranks for a particular shape before assigning the array.
- Added `MPILinearOperator` similar to `pylops-mpi-old`, added the functionality of Distribution using DistributedArray along with all the important ops such as `_AdjointLinearOperator`, `_SumLinearOperator`, etc..
- Added `MatrixMult`, _matvec and _rmatvec using DistributedArray as it will be an important op, also will need handling as it uses self.A.
- Added  `MPIBlockDiag`, currently each operator is assigned to a rank and computation happens at each rank..
- Added tests for the above