### PR TITLE
Add MPIBlockDiag and MPILinearOperator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
         mpi: ['mpich', 'openmpi', 'intelmpi']
         exclude:
           - os: macos-latest
@@ -23,9 +23,6 @@ jobs:
         # ”libfabric EFA provider is operating in a
         # condition that could result in memory
         # corruption”
-          - os: ubuntu-latest
-            python-version: '3.7'
-            mpi: 'mpich'
           - os: ubuntu-latest
             python-version: '3.8'
             mpi: 'mpich'

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -17,6 +17,7 @@ DistributedArray
 
     Partition
     DistributedArray
+    MPILinearOperator
 
 Basic operators
 ----------------

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -17,3 +17,13 @@ DistributedArray
 
     Partition
     DistributedArray
+
+Basic operators
+----------------
+
+.. currentmodule:: pylops_mpi.basicoperators
+
+.. autosummary::
+   :toctree: generated/
+
+    MPIBlockDiag

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,10 +3,10 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - python >= 3.6.4
+  - python >= 3.8.0
   - pip
   - numpy>=1.21.0
-  - scipy>=1.4.0
+  - scipy>=1.8.0
   - mpi4py
   - pylops >= 2.0
   - matplotlib

--- a/environment.yml
+++ b/environment.yml
@@ -3,9 +3,9 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - python>=3.6.4
+  - python>=3.8.0
   - numpy>=1.21.0
-  - scipy>=1.4.0
+  - scipy>=1.8.0
   - pylops>=2.0
   - matplotlib
   - mpi4py

--- a/pylops_mpi/LinearOperator.py
+++ b/pylops_mpi/LinearOperator.py
@@ -1,0 +1,332 @@
+import numpy as np
+from mpi4py import MPI
+from typing import Callable
+
+from scipy.sparse._sputils import isintlike
+from scipy.sparse.linalg._interface import _get_dtype
+
+from pylops import LinearOperator
+from pylops.utils import DTypeLike, ShapeLike
+
+from pylops_mpi import DistributedArray
+
+
+class MPILinearOperator(LinearOperator):
+    """Common interface for performing matrix-vector products in distributed fashion.
+
+    This class extends the :class:`pylops.LinearOperator`.
+    This class provides methods to perform matrix-vector product and adjoint matrix-vector
+    products using MPI.
+
+    .. note:: End users of pylops-mpi should not use this class directly but simply
+      use operators that are already implemented. This class is meant for
+      developers only, it has to be used as the parent class of any new operator
+      developed within pylops-mpi.
+
+    Parameters
+    ----------
+    shape : :obj:`tuple(int, int)`
+        Shape of the MPI Linear Operator.
+    dtype : :obj:`str`
+        Type of elements in input array.
+    Op : :obj:`pylops.LinearOperator`, optional
+        Linear Operator. Defaults to ``None``.
+    base_comm : :obj:`mpi4py.MPI.Comm`, optional
+        MPI Base Communicator. Defaults to ``mpi4py.MPI.COMM_WORLD``.
+
+    """
+
+    def __init__(self, shape: ShapeLike, dtype: DTypeLike, Op: LinearOperator = None,
+                 base_comm: MPI.Comm = MPI.COMM_WORLD):
+        self.Op = Op
+        # For MPI
+        self.base_comm = base_comm
+        self.size = self.base_comm.Get_size()
+        self.rank = self.base_comm.Get_rank()
+        super().__init__(Op=Op, dtype=dtype, shape=shape)
+
+    def matvec(self, x: DistributedArray) -> DistributedArray:
+        if self.Op:
+            y = DistributedArray(global_shape=self.base_comm.allreduce(self.shape[1]), dtype=x.dtype)
+            if isinstance(x, DistributedArray):
+                x = x.local_array
+            y[:] = self.Op._matvec(x)
+        else:
+            y = self._matvec(x)
+        return y
+
+    def rmatvec(self, x: DistributedArray) -> DistributedArray:
+        if self.Op:
+            y = DistributedArray(global_shape=self.base_comm.allreduce(self.shape[1]), dtype=x.dtype)
+            if isinstance(x, DistributedArray):
+                x = x.local_array
+            y[:] = self.Op._rmatvec(x)
+        else:
+            y = self._rmatvec(x)
+        return y
+
+    def dot(self, x: DistributedArray):
+        if isinstance(x, MPILinearOperator):
+            Op = _ProductLinearOperator(self, x)
+            Op.clinear = (getattr(self, 'clinear', True)
+                          and getattr(x, 'clinear', True))
+            return Op
+        elif np.isscalar(x):
+            return _ScaledLinearOperator(self, x)
+        else:
+            if x is None or x.ndim == 1:
+                return self.matvec(x)
+            elif x.ndim == 2:
+                return self.matmat(x)
+            else:
+                raise ValueError('expected 1-d or 2-d array or matrix, got %r'
+                                 % x)
+
+    def adjoint(self):
+        return self._adjoint()
+
+    H = property(adjoint)
+
+    def transpose(self):
+        return self._transpose()
+
+    T = property(transpose)
+
+    def __mul__(self, x):
+        return self.dot(x)
+
+    def __rmul__(self, x):
+        if np.isscalar(x):
+            return _ScaledLinearOperator(self, x)
+        else:
+            return NotImplemented
+
+    def __matmul__(self, x):
+        if np.isscalar(x):
+            raise ValueError("Scalar not allowed, use * instead")
+        return self.__mul__(x)
+
+    def __rmatmul__(self, x):
+        if np.isscalar(x):
+            raise ValueError("Scalar not allowed, use * instead")
+        return self.__rmul__(x)
+
+    def __pow__(self, p):
+        return _PowerLinearOperator(self, p)
+
+    def __add__(self, x):
+        return _SumLinearOperator(self, x)
+
+    def __neg__(self):
+        return _ScaledLinearOperator(self, -1)
+
+    def __sub__(self, x):
+        return self.__add__(-x)
+
+    def _adjoint(self):
+        return _AdjointLinearOperator(self)
+
+    def _transpose(self):
+        return _TransposedLinearOperator(self)
+
+    def conj(self):
+        return _ConjLinearOperator(self)
+
+
+class _AdjointLinearOperator(MPILinearOperator):
+    """Adjoint of MPI Linear Operator"""
+
+    def __init__(self, A: MPILinearOperator):
+        self.A = A
+        self.args = (A,)
+        super().__init__(shape=(A.shape[1], A.shape[0]), dtype=A.dtype,
+                         base_comm=MPI.COMM_WORLD)
+
+    def _matvec(self, x: DistributedArray):
+        return self.A.rmatvec(x)
+
+    def _rmatvec(self, x: DistributedArray):
+        return self.A.matvec(x)
+
+
+class _TransposedLinearOperator(MPILinearOperator):
+    """Transposition of MPI Linear Operator"""
+
+    def __init__(self, A: MPILinearOperator):
+        self.A = A
+        self.args = (A,)
+        super().__init__(shape=(A.shape[1], A.shape[0]), dtype=A.dtype,
+                         base_comm=MPI.COMM_WORLD)
+
+    def _matvec(self, x: DistributedArray):
+        x[:] = np.conj(x.local_array)
+        y = self.A.rmatvec(x)
+        y[:] = np.conj(y.local_array)
+        return y
+
+    def _rmatvec(self, x: DistributedArray):
+        x[:] = np.conj(x.local_array)
+        y = self.A.matvec(x)
+        y[:] = np.conj(y.local_array)
+        return y
+
+
+class _ProductLinearOperator(MPILinearOperator):
+    """Product of MPI LinearOperators
+    """
+    def __init__(self, A: MPILinearOperator, B: MPILinearOperator):
+        if not isinstance(A, MPILinearOperator) or not isinstance(B, MPILinearOperator):
+            raise ValueError('both operands have to be a LinearOperator')
+        if A.shape[1] != B.shape[0]:
+            raise ValueError('cannot multiply %r and %r: shape mismatch' % (A, B))
+        self.args = (A, B)
+        super().__init__(shape=(A.shape[0], B.shape[1]), dtype=_get_dtype([A, B]),
+                         base_comm=MPI.COMM_WORLD)
+
+    def _matvec(self, x: DistributedArray):
+        return self.args[0].matvec(self.args[1].matvec(x))
+
+    def _rmatvec(self, x: DistributedArray):
+        return self.args[1].rmatvec(self.args[0].rmatvec(x))
+
+    def _adjoint(self):
+        A, B = self.args
+        return B.H * A.H
+
+
+class _ScaledLinearOperator(MPILinearOperator):
+    """Scaled MPI Linear Operator
+    """
+
+    def __init__(self, A: MPILinearOperator, alpha):
+        if not isinstance(A, MPILinearOperator):
+            raise ValueError('MPILinearOperator expected as A')
+        if not np.isscalar(alpha):
+            raise ValueError('scalar expected as alpha')
+        self.args = (A, alpha)
+        super().__init__(shape=A.shape, dtype=_get_dtype([A], [type(alpha)]),
+                         base_comm=MPI.COMM_WORLD)
+
+    def _matvec(self, x: DistributedArray):
+        y = self.args[0].matvec(x)
+        if y is not None:
+            y[:] *= self.args[1]
+        return y
+
+    def _rmatvec(self, x: DistributedArray):
+        y = self.args[0].rmatvec(x)
+        if y is not None:
+            y[:] *= np.conj(self.args[1])
+        return y
+
+    def _adjoint(self):
+        A, alpha = self.args
+        return A.H * np.conj(alpha)
+
+
+class _SumLinearOperator(MPILinearOperator):
+    """Sum of MPI LinearOperators
+    """
+
+    def __init__(self, A: MPILinearOperator, B: MPILinearOperator):
+        if not isinstance(A, MPILinearOperator) or not isinstance(B, MPILinearOperator):
+            raise ValueError('both operands have to be a MPILinearOperator')
+        # Make sure it works with different kinds
+        if A.shape != B.shape:
+            raise ValueError("cannot add %r and %r: shape mismatch" % (A, B))
+        self.args = (A, B)
+        super().__init__(shape=A.shape, dtype=A.dtype, base_comm=MPI.COMM_WORLD)
+
+    def _matvec(self, x: DistributedArray):
+        arr1 = self.args[0].matvec(x)
+        arr2 = self.args[1].matvec(x)
+        return arr1 + arr2
+
+    def _rmatvec(self, x):
+        arr1 = self.args[0].rmatvec(x)
+        arr2 = self.args[1].rmatvec(x)
+        return arr1 + arr2
+
+    def _adjoint(self):
+        A, B = self.args
+        return A.H + B.H
+
+
+class _PowerLinearOperator(MPILinearOperator):
+    """Power of MPI Linear Operator
+    """
+
+    def __init__(self, A: MPILinearOperator, p: int) -> None:
+        if not isinstance(A, MPILinearOperator):
+            raise ValueError("LinearOperator expected as A")
+        if A.shape[0] != A.shape[1]:
+            raise ValueError("square LinearOperator expected, got %r" % A)
+        if not isintlike(p) or p < 0:
+            raise ValueError("non-negative integer expected as p")
+
+        super(_PowerLinearOperator, self).__init__(shape=A.shape, dtype=A.dtype, base_comm=A.base_comm)
+        self.args = (A, p)
+
+    def _power(self, fun: Callable, x: DistributedArray):
+        res = DistributedArray(global_shape=x.global_shape, dtype=x.dtype)
+        res[:] = x.local_array
+        for _ in range(self.args[1]):
+            res[:] = fun(res).local_array
+        return res
+
+    def _matvec(self, x: DistributedArray):
+        return self._power(self.args[0].matvec, x)
+
+    def _rmatvec(self, x: DistributedArray):
+        return self._power(self.args[0].rmatvec, x)
+
+
+class _ConjLinearOperator(MPILinearOperator):
+    """Complex conjugate MPI Linear Operator
+    """
+
+    def __init__(self, A: MPILinearOperator):
+        if not isinstance(A, MPILinearOperator):
+            raise TypeError('A must be a MPILinearOperator')
+        self.A = A
+        super().__init__(shape=A.shape, dtype=A.dtype, base_comm=MPI.COMM_WORLD)
+
+    def _matvec(self, x: DistributedArray):
+        x[:] = x.local_array.conj()
+        y = self.A.matvec(x)
+        if y is not None:
+            y[:] = y.local_array.conj()
+        return y
+
+    def _rmatvec(self, x: DistributedArray):
+        x[:] = x.local_array.conj()
+        y = self.A.rmatvec(x)
+        if y is not None:
+            y[:] = y.local_array.conj()
+        return y
+
+    def _adjoint(self):
+        return _ConjLinearOperator(self.A.H)
+
+
+def asmpilinearoperator(Op):
+    """Return Op as a MPI LinearOperator.
+
+    Converts a :class:`pylops.LinearOperator` to a :class:`pylops_mpi.MPILinearOperator`.
+
+    Parameters
+    ----------
+    Op : :obj:`pylops.LinearOperator`
+        PyLops LinearOperator
+
+    Returns
+    -------
+    Op : :obj:`pylops_mpi.MPILinearOperator`
+        Operator of type :obj:`pylops_mpi.MPILinearOperator`
+
+    """
+    if isinstance(Op, MPILinearOperator):
+        return Op
+    else:
+        return MPILinearOperator(shape=Op.shape, dtype=Op.dtype, Op=Op,
+                                 base_comm=MPI.COMM_WORLD)

--- a/pylops_mpi/LinearOperator.py
+++ b/pylops_mpi/LinearOperator.py
@@ -108,7 +108,7 @@ class MPILinearOperator:
         return self._rmatvec(x)
 
     def _rmatvec(self, x: DistributedArray) -> DistributedArray:
-        if self.Op is not None:
+        if self.Op:
             y = DistributedArray(global_shape=self.shape[0])
             y[:] = self.Op._rmatvec(x.local_array)
             return y

--- a/pylops_mpi/LinearOperator.py
+++ b/pylops_mpi/LinearOperator.py
@@ -39,8 +39,8 @@ class MPILinearOperator:
                  dtype: Optional[DTypeLike] = None, base_comm: MPI.Comm = MPI.COMM_WORLD):
         if Op:
             self.Op = Op
-            self.shape = Op.shape
-            self.dtype = Op.dtype
+            dtype = self.Op.dtype if dtype is None else dtype
+            shape = self.Op.shape if shape is None else shape
         if shape:
             self.shape = shape
         if dtype:

--- a/pylops_mpi/__init__.py
+++ b/pylops_mpi/__init__.py
@@ -1,6 +1,6 @@
 from .DistributedArray import DistributedArray, Partition
 from .plotting.plotting import *
-from .basicoperators import MPIBlockDiag
+from .basicoperators import *
 
 try:
     from .version import version as __version__

--- a/pylops_mpi/__init__.py
+++ b/pylops_mpi/__init__.py
@@ -1,4 +1,5 @@
 from .DistributedArray import DistributedArray, Partition
+from .LinearOperator import MPILinearOperator, asmpilinearoperator
 from .plotting.plotting import *
 from .basicoperators import *
 

--- a/pylops_mpi/__init__.py
+++ b/pylops_mpi/__init__.py
@@ -1,5 +1,6 @@
 from .DistributedArray import DistributedArray, Partition
 from .plotting.plotting import *
+from .basicoperators import MPIBlockDiag
 
 try:
     from .version import version as __version__

--- a/pylops_mpi/basicoperators/BlockDiag.py
+++ b/pylops_mpi/basicoperators/BlockDiag.py
@@ -30,12 +30,58 @@ class MPIBlockDiag(LinearOperator):
         shape : :obj:`tuple`
             Operator shape
         explicit : :obj:`bool`
-            Operator contains a matrix that can be solved explicitly (``True``) or
-            not (``False``)
+            Operator contains a matrix that can be solved explicitly (``True``) or not (``False``)
 
         Notes
         -----
-        Refer to :obj:pylops.BlockDiag for more details.
+        An MPI Block Diagonal operator is composed of N linear operators, represented by **L**.
+        Each operator performs forward mode operations using its corresponding data, denoted as **m**.
+        The data is a DistributedArray located at each rank.
+        The forward mode of each operator is then collected from all ranks as a DistributedArray, referred to as **d**.
+
+        .. math::
+          \begin{bmatrix}
+            \mathbf{d}_1 \\
+            \mathbf{d}_2 \\
+            \vdots \\
+            \mathbf{d}_n
+          \end{bmatrix} =
+          \begin{bmatrix}
+            \mathbf{L}_1 & \mathbf{0} & \ldots & \mathbf{0} \\
+            \mathbf{0} & \mathbf{L}_2 & \ldots & \mathbf{0} \\
+            \vdots & \vdots & \ddots & \vdots \\
+            \mathbf{0} & \mathbf{0} & \ldots & \mathbf{L}_n
+          \end{bmatrix}
+          \begin{bmatrix}
+            \mathbf{m}_1 \\
+            \mathbf{m}_2 \\
+            \vdots \\
+            \mathbf{m}_n
+          \end{bmatrix}
+
+        Likewise, for the adjoint mode, each operator executes operations in the adjoint mode,
+        and the results are gathered from each rank to form a DistributedArray represented by **d**.
+
+        .. math::
+          \begin{bmatrix}
+            \mathbf{d}_1 \\
+            \mathbf{d}_2 \\
+            \vdots \\
+            \mathbf{d}_n
+          \end{bmatrix} =
+          \begin{bmatrix}
+            \mathbf{L}_1^H & \mathbf{0} & \ldots & \mathbf{0} \\
+            \mathbf{0} & \mathbf{L}_2^H & \ldots & \mathbf{0} \\
+            \vdots & \vdots & \ddots & \vdots \\
+            \mathbf{0} & \mathbf{0} & \ldots & \mathbf{L}_n^H
+          \end{bmatrix}
+          \begin{bmatrix}
+            \mathbf{m}_1 \\
+            \mathbf{m}_2 \\
+            \vdots \\
+            \mathbf{m}_n
+          \end{bmatrix}
+
     """
 
     def __init__(self, ops: Sequence[LinearOperator],

--- a/pylops_mpi/basicoperators/BlockDiag.py
+++ b/pylops_mpi/basicoperators/BlockDiag.py
@@ -35,8 +35,9 @@ class MPIBlockDiag(LinearOperator):
         Notes
         -----
         An MPI Block Diagonal operator is composed of N linear operators, represented by **L**.
-        Each operator performs forward mode operations using its corresponding data, denoted as **m**.
-        The data is a DistributedArray located at each rank.
+        Each operator performs forward mode operations using its corresponding model vector, denoted as **m**.
+        This vector is effectively a :class:`pylops_mpi.DistributedArray` partitioned at each rank in such a way that
+        its local shapes agree with those of the corresponding linear operators.
         The forward mode of each operator is then collected from all ranks as a DistributedArray, referred to as **d**.
 
         .. math::
@@ -60,7 +61,8 @@ class MPIBlockDiag(LinearOperator):
           \end{bmatrix}
 
         Likewise, for the adjoint mode, each operator executes operations in the adjoint mode,
-        and the results are gathered from each rank to form a DistributedArray represented by **d**.
+        the adjoint mode of each operator is then collected from all ranks as a DistributedArray
+        referred as **d**.
 
         .. math::
           \begin{bmatrix}

--- a/pylops_mpi/basicoperators/BlockDiag.py
+++ b/pylops_mpi/basicoperators/BlockDiag.py
@@ -1,0 +1,115 @@
+import numpy as np
+import scipy as sp
+from mpi4py import MPI
+from typing import Optional, Sequence
+
+from pylops.utils import DTypeLike
+from pylops import LinearOperator, MatrixMult
+
+from pylops_mpi.DistributedArray import local_split, Partition
+
+sp_version = sp.__version__.split(".")
+if int(sp_version[0]) <= 1 and int(sp_version[1]) < 8:
+    from scipy.sparse.linalg.interface import _get_dtype
+else:
+    from scipy.sparse.linalg._interface import _get_dtype
+
+
+class MPIBlockDiag(LinearOperator):
+    r"""MPI Block-diagonal operator.
+
+        Create a block-diagonal operator from N linear operators using MPI.
+
+        Parameters
+        ----------
+        ops : :obj:`list`
+            Linear operators to be stacked. Alternatively,
+            :obj:`numpy.ndarray` or :obj:`scipy.sparse` matrices can be passed
+            in place of one or more operators.
+        base_comm : :obj:`mpi4py.MPI.Comm`, optional
+            Base MPI Communicator. Defaults to ``mpi4py.MPI.COMM_WORLD``.
+        dtype : :obj:`str`, optional
+            Type of elements in input array.
+
+        Attributes
+        ----------
+        shape : :obj:`tuple`
+            Operator shape
+        explicit : :obj:`bool`
+            Operator contains a matrix that can be solved explicitly (``True``) or
+            not (``False``)
+
+        Notes
+        -----
+        Refer to :obj:pylops.BlockDiag for more details.
+    """
+
+    def __init__(self, ops: Sequence[LinearOperator],
+                 base_comm: MPI.Comm = MPI.COMM_WORLD,
+                 dtype: Optional[DTypeLike] = None):
+        # Required for MPI
+        self.base_comm = base_comm
+        self.rank = base_comm.Get_rank()
+        self.size = base_comm.Get_size()
+        # Assign ops to different ranks
+        self.ops = self._assign_ops(ops)
+        mops = np.zeros(len(self.ops), dtype=np.int64)
+        nops = np.zeros(len(self.ops), dtype=np.int64)
+        for iop, oper in enumerate(self.ops):
+            if not isinstance(oper, LinearOperator):
+                self.ops[iop] = MatrixMult(oper, dtype=oper.dtype)
+            nops[iop] = oper.shape[0]
+            mops[iop] = oper.shape[1]
+        self.mops = mops.sum()
+        self.nops = nops.sum()
+        self.nnops = np.insert(np.cumsum(nops), 0, 0)
+        self.mmops = np.insert(np.cumsum(mops), 0, 0)
+        # Shape of the operator is equal to the sum of nops and mops at all ranks
+        self.shape = (base_comm.allreduce(self.nops), base_comm.allreduce(self.mops))
+        if dtype:
+            self.dtype = _get_dtype(dtype)
+        else:
+            self.dtype = np.dtype(dtype)
+        clinear = all([getattr(oper, "clinear", True) for oper in self.ops])
+        super().__init__(shape=self.shape, dtype=self.dtype, clinear=clinear)
+
+    def _assign_ops(self, ops):
+        r"""Assign operators to different ranks
+
+           Parameters
+           ----------
+           ops : :obj:`list`
+               Linear operators to be stacked.
+
+           Returns
+           -------
+           ops : :obj:`list`
+               Linear Operators allocated at each rank.
+        """
+        local_shapes = local_split((len(ops),), self.base_comm, Partition.SCATTER, 0)
+        x = np.insert(np.cumsum(self.base_comm.allgather(local_shapes)), 0, 0)
+        return ops[x[self.rank]:x[self.rank + 1]]
+
+    def _matvec(self, x):
+        # Calculate x_local using mops for different ranks
+        mops_sum = np.insert(np.cumsum(self.base_comm.allgather(self.mops)), 0, 0)
+        x_local = x[mops_sum[self.rank]: mops_sum[self.rank + 1]]
+        y = []
+        for iop, oper in enumerate(self.ops):
+            y.append(oper.matvec(x_local[self.mmops[iop]:
+                                         self.mmops[iop + 1]]))
+        if y:
+            y = np.concatenate(y)
+        return np.hstack(self.base_comm.allgather(y))
+
+    def _rmatvec(self, x):
+        # Calculate x_local using nops for different ranks
+        nops_sum = np.insert(np.cumsum(self.base_comm.allgather(self.nops)), 0, 0)
+        x_local = x[nops_sum[self.rank]: nops_sum[self.rank + 1]]
+        y = []
+        for iop, oper in enumerate(self.ops):
+            y.append(oper.rmatvec(x_local[self.nnops[iop]:
+                                          self.nnops[iop + 1]]))
+        if y:
+            y = np.concatenate(y)
+        return np.hstack(self.base_comm.allgather(y))

--- a/pylops_mpi/basicoperators/BlockDiag.py
+++ b/pylops_mpi/basicoperators/BlockDiag.py
@@ -1,5 +1,5 @@
 import numpy as np
-import scipy as sp
+from scipy.sparse.linalg._interface import _get_dtype
 from mpi4py import MPI
 from typing import Optional, Sequence
 
@@ -7,12 +7,6 @@ from pylops.utils import DTypeLike
 from pylops import LinearOperator, MatrixMult
 
 from pylops_mpi.DistributedArray import local_split, Partition
-
-sp_version = sp.__version__.split(".")
-if int(sp_version[0]) <= 1 and int(sp_version[1]) < 8:
-    from scipy.sparse.linalg.interface import _get_dtype
-else:
-    from scipy.sparse.linalg._interface import _get_dtype
 
 
 class MPIBlockDiag(LinearOperator):

--- a/pylops_mpi/basicoperators/BlockDiag.py
+++ b/pylops_mpi/basicoperators/BlockDiag.py
@@ -33,8 +33,6 @@ class MPIBlockDiag(MPILinearOperator):
         ----------
         shape : :obj:`tuple`
             Operator shape
-        explicit : :obj:`bool`
-            Operator contains a matrix that can be solved explicitly (``True``) or not (``False``)
 
         Notes
         -----

--- a/pylops_mpi/basicoperators/__init__.py
+++ b/pylops_mpi/basicoperators/__init__.py
@@ -1,0 +1,1 @@
+from .BlockDiag import MPIBlockDiag

--- a/pylops_mpi/basicoperators/__init__.py
+++ b/pylops_mpi/basicoperators/__init__.py
@@ -1,1 +1,18 @@
-from .BlockDiag import MPIBlockDiag
+"""
+Basic Linear Operators using MPI
+================================
+
+The subpackage basicoperators extends some of the basic linear algebra
+operations provided by numpy providing forward and adjoint functionalities
+using MPI.
+
+A list of operators present in pylops_mpi.basicoperators :
+    MPIBlockDiag                      Block Diagonal Operator
+
+"""
+
+from .BlockDiag import *
+
+__all__ = [
+    "MPIBlockDiag"
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 numpy>=1.21.0
-scipy>=1.4.0
+scipy>=1.8.0
 pylops>=2.0
 mpi4py
 matplotlib

--- a/tests/test_blockdiag.py
+++ b/tests/test_blockdiag.py
@@ -1,0 +1,31 @@
+import numpy as np
+from numpy.testing import assert_allclose
+
+np.random.seed(42)
+import pytest
+
+import pylops
+import pylops_mpi
+
+par1 = {'ny': 101, 'nx': 101, 'dtype': np.float64}
+par1j = {'ny': 101, 'nx': 101, 'dtype': np.complex128}
+par2 = {'ny': 301, 'nx': 101, 'dtype': np.float64}
+par2j = {'ny': 301, 'nx': 101, 'dtype': np.complex128}
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
+def test_blockdiag(par):
+    G1 = np.random.normal(0, 10, (par['ny'], par['nx'])).astype(par['dtype'])
+    G2 = np.random.normal(0, 10, (par['ny'], par['nx'])).astype(par['dtype'])
+    ops = [pylops.Identity(par['ny'], par['nx']),
+           pylops.Zero(par['ny'], par['nx']), pylops.MatrixMult(G1),
+           pylops.MatrixMult(G2)]
+    BDiag_MPI = pylops_mpi.MPIBlockDiag(ops=ops)
+    assert isinstance(BDiag_MPI, pylops.LinearOperator)
+    BDiag = pylops.BlockDiag(ops=ops)
+    x = np.random.normal(100, 100, (BDiag.shape[1],))
+    y = np.random.normal(100, 100, (BDiag.shape[0],))
+    assert BDiag_MPI.shape == BDiag.shape
+    assert_allclose(BDiag_MPI * x, BDiag * x, rtol=1e-14)
+    assert_allclose(BDiag_MPI.H * y, BDiag.H * y, rtol=1e-14)

--- a/tests/test_blockdiag.py
+++ b/tests/test_blockdiag.py
@@ -1,7 +1,8 @@
+from mpi4py import MPI
 import numpy as np
 from numpy.testing import assert_allclose
-
 np.random.seed(42)
+
 import pytest
 
 import pylops
@@ -16,16 +17,33 @@ par2j = {'ny': 301, 'nx': 101, 'dtype': np.complex128}
 @pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
 def test_blockdiag(par):
-    G1 = np.random.normal(0, 10, (par['ny'], par['nx'])).astype(par['dtype'])
-    G2 = np.random.normal(0, 10, (par['ny'], par['nx'])).astype(par['dtype'])
-    ops = [pylops.Identity(par['ny'], par['nx']),
-           pylops.Zero(par['ny'], par['nx']), pylops.MatrixMult(G1),
-           pylops.MatrixMult(G2)]
-    BDiag_MPI = pylops_mpi.MPIBlockDiag(ops=ops)
-    assert isinstance(BDiag_MPI, pylops.LinearOperator)
-    BDiag = pylops.BlockDiag(ops=ops)
-    x = np.random.normal(100, 100, (BDiag.shape[1],))
-    y = np.random.normal(100, 100, (BDiag.shape[0],))
-    assert BDiag_MPI.shape == BDiag.shape
-    assert_allclose(BDiag_MPI * x, BDiag * x, rtol=1e-14)
-    assert_allclose(BDiag_MPI.H * y, BDiag.H * y, rtol=1e-14)
+    size = MPI.COMM_WORLD.Get_size()
+    rank = MPI.COMM_WORLD.Get_rank()
+    Op = pylops.MatrixMult(A=((rank + 1) * np.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
+    BDiag_MPI = pylops_mpi.MPIBlockDiag(ops=[Op, ])
+
+    x = pylops_mpi.DistributedArray(global_shape=size * par['nx'], dtype=par['dtype'])
+    x[:] = np.ones(shape=par['nx'], dtype=par['dtype'])
+    x_global = x.asarray()
+
+    y = pylops_mpi.DistributedArray(global_shape=size * par['ny'], dtype=par['dtype'])
+    y[:] = np.ones(shape=par['ny'], dtype=par['dtype'])
+    y_global = y.asarray()
+
+    x_mat = BDiag_MPI._matvec(x)
+    y_rmat = BDiag_MPI._rmatvec(y)
+    assert isinstance(x_mat, pylops_mpi.DistributedArray)
+    assert isinstance(y_rmat, pylops_mpi.DistributedArray)
+
+    x_mat_mpi = x_mat.asarray()
+    y_rmat_mpi = y_rmat.asarray()
+
+    if rank == 0:
+        ops = [pylops.MatrixMult((i + 1) * np.ones(shape=(par['ny'], par['nx'])).astype(par['dtype'])) for i in range(size)]
+        BDiag = pylops.BlockDiag(ops=ops)
+
+        print(x_global.shape)
+        x_mat_np = BDiag @ x_global
+        y_rmat_np = BDiag.H @ y_global
+        assert_allclose(x_mat_mpi, x_mat_np, rtol=1e-14)
+        assert_allclose(y_rmat_mpi, y_rmat_np, rtol=1e-14)

--- a/tests/test_blockdiag.py
+++ b/tests/test_blockdiag.py
@@ -30,8 +30,8 @@ def test_blockdiag(par):
     y[:] = np.ones(shape=par['ny'], dtype=par['dtype'])
     y_global = y.asarray()
 
-    x_mat = BDiag_MPI._matvec(x)
-    y_rmat = BDiag_MPI._rmatvec(y)
+    x_mat = BDiag_MPI @ x
+    y_rmat = BDiag_MPI.H @ y
     assert isinstance(x_mat, pylops_mpi.DistributedArray)
     assert isinstance(y_rmat, pylops_mpi.DistributedArray)
 
@@ -42,7 +42,6 @@ def test_blockdiag(par):
         ops = [pylops.MatrixMult((i + 1) * np.ones(shape=(par['ny'], par['nx'])).astype(par['dtype'])) for i in range(size)]
         BDiag = pylops.BlockDiag(ops=ops)
 
-        print(x_global.shape)
         x_mat_np = BDiag @ x_global
         y_rmat_np = BDiag.H @ y_global
         assert_allclose(x_mat_mpi, x_mat_np, rtol=1e-14)

--- a/tests/test_linearop.py
+++ b/tests/test_linearop.py
@@ -1,0 +1,254 @@
+import numpy as np
+from numpy.testing import assert_allclose
+np.random.seed(42)
+import pytest
+
+from mpi4py import MPI
+
+rank = MPI.COMM_WORLD.Get_rank()
+size = MPI.COMM_WORLD.Get_size()
+
+import pylops
+
+from pylops_mpi import MPILinearOperator, MPIBlockDiag, DistributedArray
+
+par1 = {'ny': 101, 'nx': 101, 'dtype': np.float64}
+par1j = {'ny': 101, 'nx': 101, 'dtype': np.complex128}
+par2 = {'ny': 301, 'nx': 101, 'dtype': np.float64}
+par2j = {'ny': 301, 'nx': 101, 'dtype': np.complex128}
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
+def test_linearop(par):
+    Op = pylops.MatrixMult(A=((rank + 1) * np.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
+    BDiag_MPI = MPIBlockDiag(ops=[Op, ])
+    assert isinstance(BDiag_MPI, MPILinearOperator)
+    assert isinstance(BDiag_MPI.H, MPILinearOperator)
+    assert isinstance(BDiag_MPI.T, MPILinearOperator)
+    assert isinstance(BDiag_MPI * -3, MPILinearOperator)
+    assert isinstance(BDiag_MPI.conj(), MPILinearOperator)
+    assert isinstance(BDiag_MPI + BDiag_MPI, MPILinearOperator)
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par1j)])
+def test_square_linearop(par):
+    Op = pylops.MatrixMult(A=((rank + 1) * np.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
+    BDiag_MPI = MPIBlockDiag(ops=[Op, ])
+    assert isinstance(BDiag_MPI ** 4, MPILinearOperator)
+    assert isinstance(BDiag_MPI * BDiag_MPI, MPILinearOperator)
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
+def test_transpose(par):
+    """Test the TransposeLinearOperator"""
+    Op = pylops.MatrixMult(A=((rank + 1) * np.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
+    BDiag_MPI = MPIBlockDiag(ops=[Op, ])
+    # Tranposed Op
+    Top_MPI = BDiag_MPI.T
+
+    # For forward mode
+    x = DistributedArray(global_shape=size * par['ny'], dtype=par['dtype'])
+    x[:] = np.ones(par['ny'])
+    x_global = x.asarray()
+    Top_x = Top_MPI @ x
+    assert isinstance(Top_x, DistributedArray)
+    Top_x_np = Top_x.asarray()
+
+    # For adjoint mode
+    y = DistributedArray(global_shape=size * par['nx'], dtype=par['dtype'])
+    y[:] = np.ones(par['nx'])
+    y_global = y.asarray()
+    Top_y = Top_MPI.H @ y
+    assert isinstance(Top_y, DistributedArray)
+    Top_y_np = Top_y.asarray()
+    if rank == 0:
+        ops = [pylops.MatrixMult((i + 1) * np.ones(shape=(par['ny'], par['nx'])).astype(par['dtype'])) for i in
+               range(size)]
+        BDiag = pylops.BlockDiag(ops=ops)
+        Top = BDiag.T
+        assert_allclose(Top_x_np, Top @ x_global, rtol=1e-14)
+        assert_allclose(Top_y_np, Top.H @ y_global, rtol=1e-14)
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
+def test_scaled(par):
+    """Test the ScaledLinearOperator"""
+    Op = pylops.MatrixMult(A=((rank + 1) * np.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
+    BDiag_MPI = MPIBlockDiag(ops=[Op, ])
+    # Scaled Op
+    Sop_MPI = BDiag_MPI * -4
+
+    # For forward mode
+    x = DistributedArray(global_shape=size * par['nx'], dtype=par['dtype'])
+    x[:] = np.ones(par['nx'])
+    x_global = x.asarray()
+    Sop_x = Sop_MPI @ x
+    assert isinstance(Sop_x, DistributedArray)
+    Sop_x_np = Sop_x.asarray()
+
+    # For adjoint mode
+    y = DistributedArray(global_shape=size * par['ny'], dtype=par['dtype'])
+    y[:] = np.ones(par['ny'])
+    y_global = y.asarray()
+    Sop_y = Sop_MPI.H @ y
+    assert isinstance(Sop_y, DistributedArray)
+    Sop_y_np = Sop_y.asarray()
+    if rank == 0:
+        ops = [pylops.MatrixMult((i + 1) * np.ones(shape=(par['ny'], par['nx'])).astype(par['dtype'])) for i in
+               range(size)]
+        BDiag = pylops.BlockDiag(ops=ops)
+        Sop = BDiag * -4
+        assert_allclose(Sop_x_np, Sop @ x_global, rtol=1e-14)
+        assert_allclose(Sop_y_np, Sop.H @ y_global, rtol=1e-14)
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par1j)])
+def test_power(par):
+    """Test the PowerLinearOperator"""
+    Op = pylops.MatrixMult(A=((rank + 1) * np.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
+    BDiag_MPI = MPIBlockDiag(ops=[Op, ])
+    # Power Operator
+    Pop_MPI = BDiag_MPI ** 3
+
+    # Forward Mode
+    x = DistributedArray(global_shape=size * par['nx'], dtype=par['dtype'])
+    x[:] = np.ones(par['nx'])
+    x_global = x.asarray()
+    Pop_x = Pop_MPI @ x
+    assert isinstance(Pop_x, DistributedArray)
+    Pop_x_np = Pop_x.asarray()
+
+    # Adjoint Mode
+    y = DistributedArray(global_shape=size * par['ny'], dtype=par['dtype'])
+    y[:] = np.ones(par['ny'])
+    y_global = y.asarray()
+    Pop_y = Pop_MPI.H @ y
+    assert isinstance(Pop_y, DistributedArray)
+    Pop_y_np = Pop_y.asarray()
+
+    if rank == 0:
+        ops = [pylops.MatrixMult((i + 1) * np.ones(shape=(par['ny'], par['nx'])).astype(par['dtype'])) for i in
+               range(size)]
+        BDiag = pylops.BlockDiag(ops=ops)
+        Pop = BDiag ** 3
+        assert_allclose(Pop_x_np, Pop @ x_global, rtol=1e-14)
+        assert_allclose(Pop_y_np, Pop.H @ y_global, rtol=1e-14)
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
+def test_sum(par):
+    """Test the SumLinearOperator"""
+    Op1 = pylops.MatrixMult(A=((rank + 1) * np.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
+    BDiag_MPI_1 = MPIBlockDiag(ops=[Op1, ])
+
+    Op2 = pylops.MatrixMult(A=((rank + 2) * np.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
+    BDiag_MPI_2 = MPIBlockDiag(ops=[Op2, ])
+    # Sum Op
+    Sop_MPI = BDiag_MPI_1 + BDiag_MPI_2
+
+    # Forward Mode
+    x = DistributedArray(global_shape=size * par['nx'], dtype=par['dtype'])
+    x[:] = np.ones(par['nx'])
+    x_global = x.asarray()
+    Sop_x = Sop_MPI @ x
+    assert isinstance(Sop_x, DistributedArray)
+    Sop_x_np = Sop_x.asarray()
+
+    # Adjoint Mode
+    y = DistributedArray(global_shape=size * par['ny'], dtype=par['dtype'])
+    y[:] = np.ones(par['ny'])
+    y_global = y.asarray()
+    Sop_y = Sop_MPI.H @ y
+    assert isinstance(Sop_y, DistributedArray)
+    Sop_y_np = Sop_y.asarray()
+
+    if rank == 0:
+        ops1 = [pylops.MatrixMult((i + 1) * np.ones(shape=(par['ny'], par['nx'])).astype(par['dtype'])) for i in
+                range(size)]
+        BDiag = pylops.BlockDiag(ops=ops1)
+        ops2 = [pylops.MatrixMult((i + 2) * np.ones(shape=(par['ny'], par['nx'])).astype(par['dtype'])) for i in
+                range(size)]
+        BDiag2 = pylops.BlockDiag(ops=ops2)
+        Sop = BDiag + BDiag2
+        assert_allclose(Sop_x_np, Sop @ x_global, rtol=1e-14)
+        assert_allclose(Sop_y_np, Sop.H @ y_global, rtol=1e-14)
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
+def test_product(par):
+    """Test ProductLinearOperator"""
+    Op1 = pylops.MatrixMult(A=((rank + 1) * np.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
+    BDiag_MPI_1 = MPIBlockDiag(ops=[Op1, ])
+
+    Op2 = pylops.MatrixMult(A=((rank + 2) * np.ones(shape=(par['nx'], par['ny']))).astype(par['dtype']))
+    BDiag_MPI_2 = MPIBlockDiag(ops=[Op2, ])
+    # Product Op
+    Pop_MPI = BDiag_MPI_1 * BDiag_MPI_2
+
+    # Forward Mode
+    x = DistributedArray(global_shape=size * par['ny'], dtype=par['dtype'])
+    x[:] = np.ones(par['ny'])
+    x_global = x.asarray()
+    Pop_x = Pop_MPI @ x
+    assert isinstance(Pop_x, DistributedArray)
+    Pop_x_np = Pop_x.asarray()
+
+    # Adjoint Mode
+    y = DistributedArray(global_shape=size * par['ny'], dtype=par['dtype'])
+    y[:] = np.ones(par['ny'])
+    y_global = y.asarray()
+    Pop_y = Pop_MPI.H @ y
+    assert isinstance(Pop_y, DistributedArray)
+    Pop_y_np = Pop_y.asarray()
+
+    if rank == 0:
+        ops1 = [pylops.MatrixMult((i + 1) * np.ones(shape=(par['ny'], par['nx'])).astype(par['dtype'])) for i in
+                range(size)]
+        BDiag = pylops.BlockDiag(ops=ops1)
+        ops2 = [pylops.MatrixMult((i + 2) * np.ones(shape=(par['nx'], par['ny'])).astype(par['dtype'])) for i in
+                range(size)]
+        BDiag2 = pylops.BlockDiag(ops=ops2)
+        Pop = BDiag * BDiag2
+        assert_allclose(Pop_x_np, Pop @ x_global, rtol=1e-14)
+        assert_allclose(Pop_y_np, Pop.H @ y_global, rtol=1e-14)
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
+def test_conj(par):
+    """Test the ConjLinearOperator"""
+    Op = pylops.MatrixMult(A=((rank + 1) * np.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
+    BDiag_MPI = MPIBlockDiag(ops=[Op, ])
+    # Conj Op
+    Cop_MPI = BDiag_MPI.conj()
+
+    # For forward mode
+    x = DistributedArray(global_shape=size * par['nx'], dtype=par['dtype'])
+    x[:] = np.ones(par['nx'])
+    x_global = x.asarray()
+    Cop_x = Cop_MPI @ x
+    assert isinstance(Cop_x, DistributedArray)
+    Cop_x_np = Cop_x.asarray()
+
+    # For adjoint mode
+    y = DistributedArray(global_shape=size * par['ny'], dtype=par['dtype'])
+    y[:] = np.ones(par['ny'])
+    y_global = y.asarray()
+    Cop_y = Cop_MPI.H @ y
+    assert isinstance(Cop_y, DistributedArray)
+    Cop_y_np = Cop_y.asarray()
+
+    if rank == 0:
+        ops = [pylops.MatrixMult((i + 1) * np.ones(shape=(par['ny'], par['nx'])).astype(par['dtype'])) for i in
+               range(size)]
+        BDiag = pylops.BlockDiag(ops=ops)
+        Cop = BDiag.conj()
+        assert_allclose(Cop_x_np, Cop @ x_global, rtol=1e-14)
+        assert_allclose(Cop_y_np, Cop.H @ y_global, rtol=1e-14)

--- a/tests/test_linearop.py
+++ b/tests/test_linearop.py
@@ -21,6 +21,9 @@ par2j = {'ny': 301, 'nx': 101, 'dtype': np.complex128}
 @pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
 def test_linearop(par):
+    """Apply various overloaded operators (.H, .T, +, *, conj()) and ensure that the
+    returned operator is still of `pylops_mpi.MPILinearOperator` type
+    """
     Op = pylops.MatrixMult(A=((rank + 1) * np.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
     BDiag_MPI = MPIBlockDiag(ops=[Op, ])
     assert isinstance(BDiag_MPI, MPILinearOperator)
@@ -34,6 +37,9 @@ def test_linearop(par):
 @pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize("par", [(par1), (par1j)])
 def test_square_linearop(par):
+    """Apply overloaded operators (**, *) to square operators and
+    ensure that the returned operator is still of `pylops_mpi.MPILinearOperator` type
+    """
     Op = pylops.MatrixMult(A=((rank + 1) * np.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
     BDiag_MPI = MPIBlockDiag(ops=[Op, ])
     assert isinstance(BDiag_MPI ** 4, MPILinearOperator)


### PR DESCRIPTION
- Added MPIBlockDiag with _matvec and _rmatvec which now uses `DistributedArray`
- Added MPILinearOperator class 
- Added basic classes(_ScaledLinearOperator, _AdjointLinearOperator, etc) and made them input and output `DistributedArray`.
- Added tests to verify above classes.
- Upgrade scipy to `1.8` and python to `3.8`
- Updated docs for sphinx 
