### PR TITLE
Fix servedoc rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,4 @@ docupdate:
 	cd docs && make html && cd ..
 
 servedoc:
-	$(PYTHON) -m http.server --directory docs/build/html/
+	$(PYTHON) -m http.server --directory docs/build/


### PR DESCRIPTION
@rohanbabbar04 I noticed that using the servedoc rule I was getting an error. I realized that the path of the doc seems to be different from that of pylops (missing an html folder), so with this small change things work for me.

Please check this is also the case for you and merge if you experience the same :)