### PR TITLE
Added MPIHStack

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -41,6 +41,7 @@ Basic Operators
 
     MPIBlockDiag
     MPIVStack
+    MPIHStack
 
 Solvers
 -------

--- a/pylops_mpi/basicoperators/HStack.py
+++ b/pylops_mpi/basicoperators/HStack.py
@@ -3,8 +3,8 @@ from mpi4py import MPI
 from pylops import LinearOperator
 from pylops.utils import DTypeLike
 
-import pylops_mpi
 from pylops_mpi import DistributedArray, MPILinearOperator
+from .VStack import MPIVStack
 
 
 class MPIHStack(MPILinearOperator):
@@ -95,7 +95,7 @@ class MPIHStack(MPILinearOperator):
             raise ValueError("Operators have different number of rows")
         for iop, oper in enumerate(self.ops):
             self.ops[iop] = oper.H
-        self.HStack = pylops_mpi.MPIVStack(ops=self.ops, base_comm=base_comm, dtype=dtype).H
+        self.HStack = MPIVStack(ops=self.ops, base_comm=base_comm, dtype=dtype).H
         super().__init__(shape=self.HStack.shape, dtype=self.HStack.dtype, base_comm=base_comm)
 
     def _matvec(self, x: DistributedArray) -> DistributedArray:

--- a/pylops_mpi/basicoperators/HStack.py
+++ b/pylops_mpi/basicoperators/HStack.py
@@ -93,9 +93,8 @@ class MPIHStack(MPILinearOperator):
         nops = [oper.shape[0] for oper in self.ops]
         if len(set(nops)) > 1:
             raise ValueError("Operators have different number of rows")
-        for iop, oper in enumerate(self.ops):
-            self.ops[iop] = oper.H
-        self.HStack = MPIVStack(ops=self.ops, base_comm=base_comm, dtype=dtype).H
+        hops = [oper.H for oper in self.ops]
+        self.HStack = MPIVStack(ops=hops, base_comm=base_comm, dtype=dtype).H
         super().__init__(shape=self.HStack.shape, dtype=self.HStack.dtype, base_comm=base_comm)
 
     def _matvec(self, x: DistributedArray) -> DistributedArray:

--- a/pylops_mpi/basicoperators/HStack.py
+++ b/pylops_mpi/basicoperators/HStack.py
@@ -1,0 +1,105 @@
+from typing import Sequence, Optional
+from mpi4py import MPI
+from pylops import LinearOperator
+from pylops.utils import DTypeLike
+
+import pylops_mpi
+from pylops_mpi import DistributedArray, MPILinearOperator
+
+
+class MPIHStack(MPILinearOperator):
+    r"""MPI HStack Operator
+
+    Create a horizontal stack of a set of linear operators using MPI. Each rank must
+    initialize this operator by providing one or more linear operators which will
+    be computed within each rank. Both model and data vectors are of
+    :class:`pylops_mpi.DistributedArray` type.
+
+    Parameters
+    ----------
+    ops : :obj:`list`
+        One or more :class:`pylops.LinearOperator` to be horizontally stacked.
+    base_comm : :obj:`mpi4py.MPI.Comm`, optional
+        Base MPI Communicator. Defaults to ``mpi4py.MPI.COMM_WORLD``.
+    dtype : :obj:`str`, optional
+        Type of elements in input array.
+
+    Attributes
+    ----------
+    shape : :obj:`tuple`
+        Operator shape
+
+    Raises
+    ------
+    ValueError
+        If ``ops`` have different number of rows
+
+    Notes
+    -----
+    An MPIHStack is composed of N linear operators stacked horizontally, represented by **L**.
+    Each rank has one or more :class:`pylops.LinearOperator`, which we represent here compactly
+    as :math:`\mathbf{L}_i` for rank :math:`i`.
+
+    Each operator performs forward mode operations using its corresponding model vector, denoted as **m**.
+    This vector is effectively a :class:`pylops_mpi.DistributedArray`, with partition set to
+    :obj:`pylops_mpi.Partition.SCATTER` i.e. unique portions assigned to each rank.
+
+    Afterwards, a collective reduction operation is performed where matrix-vector product values from linear operators
+    are summed up, and broadcasted to all ranks in the communicator, represented by **d**.
+
+    .. math::
+          d =
+          \begin{bmatrix}
+            \mathbf{L}_1 &
+            \mathbf{L}_2 &
+            \ldots &
+            \mathbf{L}_n
+          \end{bmatrix}
+          \begin{bmatrix}
+            \mathbf{m}_1 \\
+            \mathbf{m}_2 \\
+            \vdots \\
+            \mathbf{m}_n
+          \end{bmatrix}
+
+    For the adjoint mode, each operator performs adjoint matrix-vector product using its corresponding
+    model vector, denoted by **m** which is a :class:`pylops_mpi.DistributedArray` with partition set to
+    :obj:`pylops_mpi.Partition.BROADCAST` i.e. array is broadcasted to all ranks.
+
+    Afterwards, the result of the adjoint matrix-vector product is stored in a :obj:`pylops_mpi.DistributedArray`,
+    which is represented by the variable **d**.
+
+    .. math::
+          \begin{bmatrix}
+            \mathbf{d}_1 \\
+            \mathbf{d}_2 \\
+            \vdots \\
+            \mathbf{d}_n
+          \end{bmatrix} =
+          \begin{bmatrix}
+            \mathbf{L}_1^H \\
+            \mathbf{L}_2^H \\
+            \vdots \\
+            \mathbf{L}_n^H
+          \end{bmatrix}
+          m
+
+    """
+
+    def __init__(self, ops: Sequence[LinearOperator],
+                 base_comm: MPI.Comm = MPI.COMM_WORLD,
+                 dtype: Optional[DTypeLike] = None):
+        self.ops = ops
+        nops = [oper.shape[0] for oper in self.ops]
+        if len(set(nops)) > 1:
+            raise ValueError("Operators have different number of rows")
+        for iop, oper in enumerate(self.ops):
+            self.ops[iop] = oper.H
+        self.HStack = pylops_mpi.MPIVStack(ops=self.ops, base_comm=base_comm, dtype=dtype).H
+        super().__init__(shape=self.HStack.shape, dtype=self.HStack.dtype, base_comm=base_comm)
+
+    def _matvec(self, x: DistributedArray) -> DistributedArray:
+        return self.HStack.matvec(x)
+
+    def _rmatvec(self, x: DistributedArray) -> DistributedArray:
+        return self.HStack.rmatvec(x)

--- a/pylops_mpi/basicoperators/__init__.py
+++ b/pylops_mpi/basicoperators/__init__.py
@@ -9,13 +9,16 @@ using MPI.
 A list of operators present in pylops_mpi.basicoperators :
     MPIBlockDiag                      Block Diagonal Operator
     MPIVStack                         Vertical Stacking
+    MPIHStack                         Horizontal Stacking
 
 """
 
 from .BlockDiag import *
 from .VStack import *
+from .HStack import *
 
 __all__ = [
     "MPIBlockDiag",
-    "MPIVStack"
+    "MPIVStack",
+    "MPIHStack"
 ]

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -51,3 +51,44 @@ def test_vstack(par):
         y_rmat_np = VStack.H @ y_global
         assert_allclose(x_mat_mpi, x_mat_np, rtol=1e-14)
         assert_allclose(y_rmat_mpi, y_rmat_np, rtol=1e-14)
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
+def test_hstack(par):
+    """Test the MPIHStack operator"""
+    size = MPI.COMM_WORLD.Get_size()
+    rank = MPI.COMM_WORLD.Get_rank()
+    A = np.ones(shape=(par['ny'], par['nx'])) + par['imag'] * np.ones(shape=(par['ny'], par['nx']))
+    Op = pylops.MatrixMult(A=((rank + 1) * A).astype(par['dtype']))
+    HStack_MPI = pylops_mpi.MPIHStack(ops=[Op, ])
+
+    # Scattered DistributedArray
+    x = pylops_mpi.DistributedArray(global_shape=size * par['nx'],
+                                    partition=pylops_mpi.Partition.SCATTER,
+                                    dtype=par['dtype'])
+    x[:] = np.ones(shape=par['nx'], dtype=par['dtype'])
+    x_global = x.asarray()
+
+    # Broadcasted DistributedArray(global_shape == local_shape)
+    y = pylops_mpi.DistributedArray(global_shape=par['ny'],
+                                    partition=pylops_mpi.Partition.BROADCAST,
+                                    dtype=par['dtype'])
+    y[:] = np.ones(shape=par['ny'], dtype=par['dtype'])
+    y_global = y.asarray()
+
+    x_mat = HStack_MPI @ x
+    y_rmat = HStack_MPI.H @ y
+    assert isinstance(x_mat, pylops_mpi.DistributedArray)
+    assert isinstance(y_rmat, pylops_mpi.DistributedArray)
+
+    x_mat_mpi = x_mat.asarray()
+    y_rmat_mpi = y_rmat.asarray()
+
+    if rank == 0:
+        ops = [pylops.MatrixMult(A=((i + 1) * A).astype(par['dtype'])) for i in range(size)]
+        HStack = pylops.HStack(ops=ops)
+        x_mat_np = HStack @ x_global
+        y_rmat_np = HStack.H @ y_global
+        assert_allclose(x_mat_mpi, x_mat_np, rtol=1e-14)
+        assert_allclose(y_rmat_mpi, y_rmat_np, rtol=1e-14)


### PR DESCRIPTION
- Added `MPIHStack`
- Added test for MPIHStack.

MPIHStack now works similar to the `pylops.HStack`, I have used the concept -> `HStack(ops) = VStack(ops.H).H`.
```
# In code 
self.HStack = pylops_mpi.MPIVStack(ops=hops, base_comm=base_comm, dtype=dtype).H
```
which creates the HStack and then called the matvec and rmatvec of MPIVStack.
The docs is pretty much the same as MPIVStack...