### PR TITLE
Added support for broadcast in `_matvec` and `_rmatvec` in MPILinearOperator

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -30,6 +30,7 @@ Templates
    :toctree: generated/
 
     MPILinearOperator
+    asmpilinearoperator
 
 Basic Operators
 ~~~~~~~~~~~~~~~

--- a/examples/plot_mpilinop.py
+++ b/examples/plot_mpilinop.py
@@ -1,0 +1,97 @@
+r"""
+MPILinearOperator
+=================
+
+This example demonstrates the use of the :py:class:`pylops_mpi.MPILinearOperator` to wrap
+PyLops Operators. PyLops operators can be converted into :py:class:`pylops_mpi.MPILinearOperator`
+using the :py:func:`pylops_mpi.asmpilinearoperator` method. Additionally, the example showcases
+how to use these wrapped PyLops operators with other operators provided by PyLops-MPI.
+
+"""
+
+import numpy as np
+from mpi4py import MPI
+from matplotlib import pyplot as plt
+
+import pylops
+
+import pylops_mpi
+
+np.random.seed(42)
+plt.close("all")
+rank = MPI.COMM_WORLD.Get_rank()
+size = MPI.COMM_WORLD.Get_size()
+
+###############################################################################
+# Let's start by creating an instance of the :py:class:`pylops.FirstDerivative`,
+# which we will then convert into an MPILinearOperator using the :py:func:`pylops_mpi.asmpilinearoperator`
+# method.
+Ny, Nx = 11, 22
+Fop = pylops.FirstDerivative(dims=(Ny, Nx), axis=0, dtype=np.float64)
+Mop = pylops_mpi.asmpilinearoperator(Op=Fop)
+print(Mop)
+
+###############################################################################
+# Now, to carry out the matrix-vector product using the MPILinearOperator, we first
+# create a :py:class:`pylops_mpi.DistributedArray` with the partition set to
+# ``pylops_mpi.Partition.BROADCAST``, denoted by :math:`x`. The matrix-vector product
+# is then computed at each rank, and the result returned is a :py:class:`pylops_mpi.DistributedArray`
+# with the same partitioning.
+x = pylops_mpi.DistributedArray(global_shape=Ny * Nx, partition=pylops_mpi.Partition.BROADCAST)
+x[:] = 1
+y = Mop @ x
+print(y)
+
+###############################################################################
+# Next, we can take the MPILinearOperator and combine it with other
+# operators provided by pylops_mpi to create more advanced MPI operators.
+# In this example, we'll combine the :py:class:`pylops_mpi.MPILinearOperator` with
+# the :py:class:`pylops_mpi.basicoperators.MPIVStack` and perform matrix-vector
+# multiplication and adjoint matrix-vector multiplication.
+Sop = pylops.SecondDerivative(dims=(Ny, Nx), axis=0, dtype=np.float64)
+VStack = pylops_mpi.MPIVStack(ops=[(rank + 1) * Sop, ])
+FullOp = VStack @ Mop
+
+###############################################################################
+# To perform the matrix vector multiplication on the full operator, we will use
+# a :py:class:`pylops_mpi.DistributedArray` with partition set to
+# ``pylops_mpi.Partition.BROADCAST``.
+X = np.zeros(shape=(Ny, Nx))
+X[Ny // 2, Nx // 2] = 1
+X1 = X.ravel()
+x = pylops_mpi.DistributedArray(global_shape=Ny * Nx, partition=pylops_mpi.Partition.BROADCAST)
+x[:] = X1
+y_dist = FullOp @ x
+y = y_dist.asarray().reshape((size * Ny, Nx))
+if rank == 0:
+    fig, ax = plt.subplots(nrows=1, ncols=2, figsize=(10, 3))
+    im1 = ax[0].imshow(X, interpolation="nearest")
+    ax[0].set_title("$x$")
+    ax[0].axis("tight")
+    fig.colorbar(im1, ax=ax[0])
+    im2 = ax[1].imshow(y, interpolation="nearest")
+    ax[1].set_title("$y$")
+    ax[1].axis("tight")
+    fig.colorbar(im2, ax=ax[1])
+    fig.suptitle("Forward", fontsize=14, fontweight="bold")
+
+###############################################################################
+# For adjoint matrix-vector multiplication, we will use a :py:class:`pylops_mpi.DistributedArray`
+# with the partition set to ``pylops_mpi.Partition.SCATTER``. It is essential
+# to ensure that the operators align appropriately with their corresponding
+# :math:`x` during this process.
+x = pylops_mpi.DistributedArray(global_shape=size * Ny * Nx, partition=pylops_mpi.Partition.SCATTER)
+x[:] = X1
+y_dist = FullOp.H @ x
+y = y_dist.asarray().reshape((Ny, Nx))
+if rank == 0:
+    fig, ax = plt.subplots(nrows=1, ncols=2, figsize=(10, 3))
+    im1 = ax[0].imshow(X, interpolation="nearest")
+    ax[0].set_title("$x$")
+    ax[0].axis("tight")
+    fig.colorbar(im1, ax=ax[0])
+    im2 = ax[1].imshow(y, interpolation="nearest")
+    ax[1].set_title("$y$")
+    ax[1].axis("tight")
+    fig.colorbar(im2, ax=ax[1])
+    fig.suptitle("Adjoint", fontsize=14, fontweight="bold")

--- a/examples/plot_mpilinop.py
+++ b/examples/plot_mpilinop.py
@@ -40,7 +40,7 @@ print(Mop)
 x = pylops_mpi.DistributedArray(global_shape=Ny * Nx, partition=pylops_mpi.Partition.BROADCAST)
 x[:] = 1
 y = Mop @ x
-print(y)
+print(f'y: {y}')
 
 ###############################################################################
 # Next, we can take the MPILinearOperator and combine it with other

--- a/pylops_mpi/LinearOperator.py
+++ b/pylops_mpi/LinearOperator.py
@@ -77,7 +77,11 @@ class MPILinearOperator:
 
     def _matvec(self, x: DistributedArray) -> DistributedArray:
         if self.Op:
-            y = DistributedArray(global_shape=self.shape[1])
+            y = DistributedArray(global_shape=self.shape[0],
+                                 base_comm=self.base_comm,
+                                 partition=x.partition,
+                                 axis=x.axis,
+                                 dtype=self.dtype)
             y[:] = self.Op._matvec(x.local_array)
             return y
 
@@ -109,7 +113,11 @@ class MPILinearOperator:
 
     def _rmatvec(self, x: DistributedArray) -> DistributedArray:
         if self.Op:
-            y = DistributedArray(global_shape=self.shape[0])
+            y = DistributedArray(global_shape=self.shape[1],
+                                 base_comm=self.base_comm,
+                                 partition=x.partition,
+                                 axis=x.axis,
+                                 dtype=self.dtype)
             y[:] = self.Op._rmatvec(x.local_array)
             return y
 

--- a/tests/test_linearop.py
+++ b/tests/test_linearop.py
@@ -10,7 +10,14 @@ size = MPI.COMM_WORLD.Get_size()
 
 import pylops
 
-from pylops_mpi import MPILinearOperator, MPIBlockDiag, DistributedArray
+from pylops_mpi import (
+    asmpilinearoperator,
+    DistributedArray,
+    MPILinearOperator,
+    MPIBlockDiag,
+    MPIVStack,
+    Partition
+)
 
 par1 = {'ny': 101, 'nx': 101, 'dtype': np.float64}
 par1j = {'ny': 101, 'nx': 101, 'dtype': np.complex128}
@@ -258,3 +265,46 @@ def test_conj(par):
         Cop = BDiag.conj()
         assert_allclose(Cop_x_np, Cop @ x_global, rtol=1e-14)
         assert_allclose(Cop_y_np, Cop.H @ y_global, rtol=1e-14)
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
+def test_mpilinop(par):
+    """Wrapping the Pylops Linear Operators"""
+    Fop = pylops.FirstDerivative(dims=(par['ny'], par['nx']), axis=0, dtype=par['dtype'])
+    Mop = asmpilinearoperator(Op=Fop)
+    assert isinstance(Mop, MPILinearOperator)
+    # DistributedArray with partition="BROADCAST"
+    x = DistributedArray(global_shape=Mop.shape[1],
+                         partition=Partition.BROADCAST, dtype=par['dtype'])
+    x[:] = np.random.normal(1, 10, x.local_shape).astype(par['dtype'])
+    x_global = x.asarray()
+    # Test for single MPILinearOperator
+    y_dist = Mop @ x
+    y = y_dist.asarray()
+
+    # Test Product of MPIVStack and MPILinearOperator
+    Sop = pylops.SecondDerivative(dims=(par['ny'], par['nx']), axis=0, dtype=par['dtype'])
+    VStack_MPI = MPIVStack(ops=[(rank + 1) * Sop, ])
+    FullOp_MPI = VStack_MPI @ Mop
+    # Forward
+    y_full_dist = FullOp_MPI @ x
+    y_full = y_full_dist.asarray()
+
+    # Adjoint
+    # DistributedArray with partition="SCATTER"
+    x_adj = DistributedArray(global_shape=FullOp_MPI.shape[0],
+                             partition=Partition.SCATTER, dtype=par['dtype'])
+    x_adj[:] = np.random.normal(0, 1, x.local_shape).astype(par['dtype'])
+    x_adj_global = x_adj.asarray()
+    y_adj_dist = FullOp_MPI.H @ x_adj
+    y_adj = y_adj_dist.asarray()
+
+    if rank == 0:
+        assert_allclose(y, Fop @ x_global, rtol=1e-14)
+        VStack = pylops.VStack(ops=[(i + 1) * Sop for i in range(size)])
+        FullOp = VStack @ Fop
+        y_np = FullOp @ x_global
+        y_adj_np = FullOp.H @ x_adj_global
+        assert_allclose(y_full, y_np, rtol=1e-14)
+        assert_allclose(y_adj, y_adj_np.flatten(), rtol=1e-14)

--- a/tests/test_linearop.py
+++ b/tests/test_linearop.py
@@ -1,12 +1,7 @@
 import numpy as np
 from numpy.testing import assert_allclose
-np.random.seed(42)
-import pytest
-
 from mpi4py import MPI
-
-rank = MPI.COMM_WORLD.Get_rank()
-size = MPI.COMM_WORLD.Get_size()
+import pytest
 
 import pylops
 
@@ -18,6 +13,10 @@ from pylops_mpi import (
     MPIVStack,
     Partition
 )
+
+np.random.seed(42)
+rank = MPI.COMM_WORLD.Get_rank()
+size = MPI.COMM_WORLD.Get_size()
 
 par1 = {'ny': 101, 'nx': 101, 'dtype': np.float64}
 par1j = {'ny': 101, 'nx': 101, 'dtype': np.complex128}
@@ -270,41 +269,86 @@ def test_conj(par):
 @pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
 def test_mpilinop(par):
-    """Wrapping the Pylops Linear Operators"""
+    """Wrapping the Pylops Linear Operator"""
     Fop = pylops.FirstDerivative(dims=(par['ny'], par['nx']), axis=0, dtype=par['dtype'])
     Mop = asmpilinearoperator(Op=Fop)
     assert isinstance(Mop, MPILinearOperator)
-    # DistributedArray with partition="BROADCAST"
+
+    # Use Partition="BROADCAST" for a single operator
+    # Forward
     x = DistributedArray(global_shape=Mop.shape[1],
                          partition=Partition.BROADCAST, dtype=par['dtype'])
     x[:] = np.random.normal(1, 10, x.local_shape).astype(par['dtype'])
     x_global = x.asarray()
-    # Test for single MPILinearOperator
     y_dist = Mop @ x
     y = y_dist.asarray()
 
-    # Test Product of MPIVStack and MPILinearOperator
-    Sop = pylops.SecondDerivative(dims=(par['ny'], par['nx']), axis=0, dtype=par['dtype'])
-    VStack_MPI = MPIVStack(ops=[(rank + 1) * Sop, ])
-    FullOp_MPI = VStack_MPI @ Mop
-    # Forward
-    y_full_dist = FullOp_MPI @ x
-    y_full = y_full_dist.asarray()
-
     # Adjoint
-    # DistributedArray with partition="SCATTER"
-    x_adj = DistributedArray(global_shape=FullOp_MPI.shape[0],
-                             partition=Partition.SCATTER, dtype=par['dtype'])
-    x_adj[:] = np.random.normal(0, 1, x.local_shape).astype(par['dtype'])
-    x_adj_global = x_adj.asarray()
-    y_adj_dist = FullOp_MPI.H @ x_adj
+    x = DistributedArray(global_shape=Mop.shape[0],
+                         partition=Partition.BROADCAST, dtype=par['dtype'])
+    x[:] = np.random.normal(1, 10, x.local_shape).astype(par['dtype'])
+    x_adj_global = x.asarray()
+    y_adj_dist = Mop.H @ x
     y_adj = y_adj_dist.asarray()
 
     if rank == 0:
         assert_allclose(y, Fop @ x_global, rtol=1e-14)
+        assert_allclose(y_adj, Fop.H @ x_adj_global, rtol=1e-14)
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
+def test_fwd_mpilinop(par):
+    """Test MPILinearOperator with other basic operators
+        Matrix-Vector Product
+    """
+    Fop = pylops.FirstDerivative(dims=(par['ny'], par['nx']), axis=0, dtype=par['dtype'])
+    Sop = pylops.SecondDerivative(dims=(par['ny'], par['nx']), axis=0, dtype=par['dtype'])
+    Mop = asmpilinearoperator(Op=Fop)
+    VStack_MPI = MPIVStack(ops=[(rank + 1) * Sop, ])
+    # Product of MPIVStack and MPILinearOperator
+    FullOp_MPI = VStack_MPI @ Mop
+
+    # Broadcasted DistributedArray
+    x = DistributedArray(global_shape=FullOp_MPI.shape[1], partition=Partition.BROADCAST, dtype=par['dtype'])
+    x[:] = np.random.normal(1, 10, x.local_shape).astype(par['dtype'])
+    x_global = x.asarray()
+
+    # Forward
+    y_dist = FullOp_MPI @ x
+    y = y_dist.asarray()
+
+    if rank == 0:
         VStack = pylops.VStack(ops=[(i + 1) * Sop for i in range(size)])
         FullOp = VStack @ Fop
         y_np = FullOp @ x_global
-        y_adj_np = FullOp.H @ x_adj_global
-        assert_allclose(y_full, y_np, rtol=1e-14)
-        assert_allclose(y_adj, y_adj_np.flatten(), rtol=1e-14)
+        assert_allclose(y, y_np.flatten(), rtol=1e-14)
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
+def test_adj_mpilinop(par):
+    """Test MPILinearOperator with other basic operators
+        Adjoint Matrix-Vector Product
+    """
+    Fop = pylops.FirstDerivative(dims=(par['ny'], par['nx']), axis=0, dtype=par['dtype'])
+    Sop = pylops.SecondDerivative(dims=(par['ny'], par['nx']), axis=0, dtype=par['dtype'])
+    Mop = asmpilinearoperator(Op=Fop)
+    VStack_MPI = MPIVStack(ops=[(rank + 1) * Sop, ])
+    # Product of MPIVStack and MPILinearOperator
+    FullOp_MPI = VStack_MPI @ Mop
+
+    # Scattered DistributedArray
+    x = DistributedArray(global_shape=FullOp_MPI.shape[0], partition=Partition.SCATTER, dtype=par['dtype'])
+    x[:] = np.random.normal(1, 10, x.local_shape).astype(par['dtype'])
+    x_global = x.asarray()
+
+    # Adjoint
+    y_dist = FullOp_MPI.H @ x
+    y = y_dist.asarray()
+
+    if rank == 0:
+        VStack = pylops.VStack(ops=[(i + 1) * Sop for i in range(size)])
+        FullOp = VStack @ Fop
+        y_np = FullOp.H @ x_global
+        assert_allclose(y, y_np.flatten(), rtol=1e-14)


### PR DESCRIPTION
Adds #47 
- Added support for broadcast in `_matvec` and `_rmatvec`.
- Added a test to check the above..