### PR TITLE
Updated tests in test_solver

### DIFF
--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -86,7 +86,7 @@ par4j = {
     "par", [(par1), (par1j), (par2), (par2j), (par3), (par3j), (par4), (par4j)]
 )
 def test_cgls(par):
-    """CGLS with MPILinearOperator"""
+    """CGLS with MPIBlockDiag"""
     A = np.ones((par["ny"], par["nx"])) + par[
         "imag"] * np.ones((par["ny"], par["nx"]))
     Aop = MatrixMult(np.conj(A.T) @ A + 1e-5 * np.eye(par["nx"], dtype=par['dtype']),

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -87,10 +87,10 @@ par4j = {
 )
 def test_cgls(par):
     """CGLS with MPILinearOperator"""
-    A = (rank + 1) * np.ones((par["ny"], par["nx"])) + (rank + 2) * par[
-        "imag"
-    ] * np.ones((par["ny"], par["nx"]))
-    Aop = MatrixMult(A, dtype=par["dtype"])
+    A = np.ones((par["ny"], par["nx"])) + par[
+        "imag"] * np.ones((par["ny"], par["nx"]))
+    Aop = MatrixMult(np.conj(A.T) @ A + 1e-5 * np.eye(par["nx"], dtype=par['dtype']),
+                     dtype=par['dtype'])
     BDiag_MPI = MPIBlockDiag(ops=[Aop, ])
 
     x = DistributedArray(global_shape=size * par['nx'], dtype=par['dtype'])
@@ -109,9 +109,10 @@ def test_cgls(par):
     assert isinstance(xinv, DistributedArray)
     xinv_array = xinv.asarray()
     if rank == 0:
-        ops = [MatrixMult((i + 1) * np.ones((par["ny"], par["nx"])) + (i + 2) * par[
-            "imag"
-        ] * np.ones((par["ny"], par["nx"])), dtype=par['dtype']) for i in range(size)]
+        mats = [np.ones(shape=(par["ny"], par["nx"])) + par[
+            "imag"] * np.ones(shape=(par["ny"], par["nx"])) for i in range(size)]
+        ops = [MatrixMult(np.conj(mats[i].T) @ mats[i] + 1e-5 * np.eye(par["nx"], dtype=par['dtype']),
+                          dtype=par['dtype']) for i in range(size)]
         BDiag = BlockDiag(ops=ops)
         if par["x0"]:
             x0 = x0_global
@@ -172,10 +173,10 @@ def test_cgls_broadcastdata(par):
 )
 def test_cgls_broadcastmodel(par):
     """CGLS with broadcasted model vector"""
-    A = (rank + 1) * np.ones((par["ny"], par["nx"])) + (rank + 2) * par[
-        "imag"
-    ] * np.ones((par["ny"], par["nx"]))
-    Aop = MatrixMult(A, dtype=par["dtype"])
+    A = np.ones((par["ny"], par["nx"])) + par[
+        "imag"] * np.ones((par["ny"], par["nx"]))
+    Aop = MatrixMult(np.conj(A.T) @ A + 1e-5 * np.eye(par["nx"], dtype=par['dtype']),
+                     dtype=par['dtype'])
     VStack_MPI = MPIVStack(ops=[Aop, ])
 
     x = DistributedArray(global_shape=par['nx'], dtype=par['dtype'], partition=Partition.BROADCAST)
@@ -197,9 +198,10 @@ def test_cgls_broadcastmodel(par):
     assert isinstance(xinv, DistributedArray)
     xinv_array = xinv.asarray()
     if rank == 0:
-        ops = [MatrixMult((i + 1) * np.ones((par["ny"], par["nx"])) + (i + 2) * par[
-            "imag"
-        ] * np.ones((par["ny"], par["nx"])), dtype=par['dtype']) for i in range(size)]
+        mats = [np.ones(shape=(par["ny"], par["nx"])) + par[
+            "imag"] * np.ones(shape=(par["ny"], par["nx"])) for i in range(size)]
+        ops = [MatrixMult(np.conj(mats[i].T) @ mats[i] + 1e-5 * np.eye(par["nx"], dtype=par['dtype']),
+                          dtype=par['dtype']) for i in range(size)]
         Vstack = VStack(ops=ops)
         if par["x0"]:
             x0 = x0_global

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -91,6 +91,7 @@ def test_cgls(par):
         "imag"] * np.ones((par["ny"], par["nx"]))
     Aop = MatrixMult(np.conj(A.T) @ A + 1e-5 * np.eye(par["nx"], dtype=par['dtype']),
                      dtype=par['dtype'])
+    # To make MPIBlockDiag a positive definite matrix
     BDiag_MPI = MPIBlockDiag(ops=[Aop, ])
 
     x = DistributedArray(global_shape=size * par['nx'], dtype=par['dtype'])
@@ -113,6 +114,7 @@ def test_cgls(par):
             "imag"] * np.ones(shape=(par["ny"], par["nx"])) for i in range(size)]
         ops = [MatrixMult(np.conj(mats[i].T) @ mats[i] + 1e-5 * np.eye(par["nx"], dtype=par['dtype']),
                           dtype=par['dtype']) for i in range(size)]
+        # To make BlockDiag a positive definite matrix
         BDiag = BlockDiag(ops=ops)
         if par["x0"]:
             x0 = x0_global
@@ -177,6 +179,7 @@ def test_cgls_broadcastmodel(par):
         "imag"] * np.ones((par["ny"], par["nx"]))
     Aop = MatrixMult(np.conj(A.T) @ A + 1e-5 * np.eye(par["nx"], dtype=par['dtype']),
                      dtype=par['dtype'])
+    # To make MPIVStack a positive definite matrix
     VStack_MPI = MPIVStack(ops=[Aop, ])
 
     x = DistributedArray(global_shape=par['nx'], dtype=par['dtype'], partition=Partition.BROADCAST)
@@ -202,6 +205,7 @@ def test_cgls_broadcastmodel(par):
             "imag"] * np.ones(shape=(par["ny"], par["nx"])) for i in range(size)]
         ops = [MatrixMult(np.conj(mats[i].T) @ mats[i] + 1e-5 * np.eye(par["nx"], dtype=par['dtype']),
                           dtype=par['dtype']) for i in range(size)]
+        # To make VStack a positive definite matrix
         Vstack = VStack(ops=ops)
         if par["x0"]:
             x0 = x0_global


### PR DESCRIPTION
Closes #51 
- Updated tests for MPIBlockDiag and MPIVStack

In the example, you used `BlockDiag(..., forceflat=True)`, but I think `forceflat` has not been released yet, so kept it as BlockDiag.