### PR TITLE
Sphinx-version bug Solved

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -15,7 +15,7 @@ dependencies:
   - pytest-mpi
   - pytest-runner
   - setuptools_scm
-  - Sphinx<7.2.0
+  - Sphinx
   - numpydoc
   - numba
   - nbsphinx

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ matplotlib
 pytest
 pytest-mpi
 pydata-sphinx-theme
-sphinx<7.2.0
+sphinx
 numpydoc
 numba
 nbsphinx


### PR DESCRIPTION
- [#11604](https://github.com/sphinx-doc/sphinx/issues/11604 ) Sphinx now works with 7.2.2 version
- Sphinx-gallery also updated to 0.14.0