### PR TITLE
CG/CGLS supporting StackedDistributedArray

### DIFF
--- a/examples/plot_cgls.py
+++ b/examples/plot_cgls.py
@@ -45,7 +45,11 @@ y = BDiag @ x
 # are then obtained in a :py:class:`pylops_mpi.DistributedArray`. To obtain the
 # overall inversion of the entire MPIBlockDiag, you can utilize the ``asarray()``
 # function of the DistributedArray as shown below.
-xinv, istop, niter, r1norm, r2norm, cost = pylops_mpi.cgls(BDiag, y, niter=15, tol=1e-10, show=True)
+
+# Set initial guess `x0` to zeroes
+x0 = pylops_mpi.DistributedArray(BDiag.shape[1], dtype=np.float128)
+x0[:] = 0
+xinv, istop, niter, r1norm, r2norm, cost = pylops_mpi.cgls(BDiag, y, x0=x0, niter=15, tol=1e-10, show=True)
 xinv_array = xinv.asarray()
 
 if rank == 0:

--- a/pylops_mpi/DistributedArray.py
+++ b/pylops_mpi/DistributedArray.py
@@ -593,12 +593,17 @@ class StackedDistributedArray:
     ----------
     distarrays : :obj:`list`
         List of :class:`pylops_mpi.DistributedArray` objects.
-
+    base_comm : :obj:`mpi4py.MPI.Comm`, optional
+        Base MPI Communicator.
+        Defaults to ``mpi4py.MPI.COMM_WORLD``.
     """
 
-    def __init__(self, distarrays: List):
+    def __init__(self, distarrays: List, base_comm: MPI.Comm = MPI.COMM_WORLD):
         self.distarrays = distarrays
         self.narrays = len(distarrays)
+        self.base_comm = base_comm
+        self.rank = base_comm.Get_rank()
+        self.size = base_comm.Get_size()
 
     def __getitem__(self, index):
         return self.distarrays[index]
@@ -674,6 +679,8 @@ class StackedDistributedArray:
         return self
 
     def multiply(self, stacked_array):
+        """Stacked Distributed Multiplication of arrays
+        """
         if isinstance(stacked_array, StackedDistributedArray):
             self._check_stacked_size(stacked_array)
         ProductArray = self.copy()
@@ -689,6 +696,8 @@ class StackedDistributedArray:
         return ProductArray
 
     def dot(self, stacked_array):
+        """Dot Product of Stacked Distributed Arrays
+        """
         self._check_stacked_size(stacked_array)
         dotprod = 0.
         for iarr in range(self.narrays):

--- a/pylops_mpi/optimization/basic.py
+++ b/pylops_mpi/optimization/basic.py
@@ -1,14 +1,19 @@
 from typing import Callable, Optional, Tuple, Union
 
 from pylops.utils import NDArray
-from pylops_mpi import MPILinearOperator, DistributedArray, StackedDistributedArray
+from pylops_mpi import (
+    MPILinearOperator,
+    DistributedArray,
+    StackedDistributedArray,
+    MPIStackedLinearOperator
+)
 from pylops_mpi.optimization.cls_basic import CG, CGLS
 
 
 def cg(
-        Op: MPILinearOperator,
-        y: Union[DistributedArray, StackedDistributedArray] ,
-        x0: Optional[DistributedArray] = None,
+        Op: Union[MPILinearOperator, MPIStackedLinearOperator],
+        y: Union[DistributedArray, StackedDistributedArray],
+        x0: Union[DistributedArray, StackedDistributedArray],
         niter: int = 10,
         tol: float = 1e-4,
         show: bool = False,
@@ -17,16 +22,16 @@ def cg(
 ) -> Tuple[Union[DistributedArray, StackedDistributedArray], int, NDArray]:
     r"""Conjugate gradient
 
-    Solve a square system of equations given an MPILinearOperator ``Op`` and
+    Solve a square system of equations given either an MPILinearOperator or an MPIStackedLinearOperator ``Op`` and
     distributed data ``y`` using conjugate gradient iterations.
 
     Parameters
     ----------
-    Op : :obj:`pylops_mpi.MPILinearOperator`
+    Op : :obj:`pylops_mpi.MPILinearOperator` or :obj:`pylops_mpi.MPIStackedLinearOperator`
         Operator to invert of size :math:`[N \times N]`
     y : :obj:`pylops_mpi.DistributedArray` or :obj:`pylops_mpi.StackedDistributedArray`
         DistributedArray of size (N,)
-    x0 : :obj:`pylops_mpi.DistributedArray` or :obj:`pylops_mpi.StackedDistributedArray`, optional
+    x0 : :obj:`pylops_mpi.DistributedArray` or :obj:`pylops_mpi.StackedDistributedArray`
         Initial guess
     niter : :obj:`int`, optional
         Number of iterations
@@ -66,9 +71,9 @@ def cg(
 
 
 def cgls(
-        Op: MPILinearOperator,
+        Op: Union[MPILinearOperator, MPIStackedLinearOperator],
         y: Union[DistributedArray, StackedDistributedArray],
-        x0: Optional[Union[DistributedArray, StackedDistributedArray]] = None,
+        x0: Union[DistributedArray, StackedDistributedArray],
         niter: int = 10,
         damp: float = 0.0,
         tol: float = 1e-4,
@@ -78,16 +83,16 @@ def cgls(
 ) -> Tuple[DistributedArray, int, int, float, float, NDArray]:
     r"""Conjugate gradient least squares
 
-    Solve an overdetermined system of equations given a MPILinearOperator ``Op`` and
+    Solve an overdetermined system of equations given either an MPILinearOperator or an MPIStackedLinearOperator``Op`` and
     distributed data ``y`` using conjugate gradient iterations.
 
     Parameters
     ----------
-    Op : :obj:`pylops_mpi.MPILinearOperator`
+    Op : :obj:`pylops_mpi.MPILinearOperator` or :obj:`pylops_mpi.MPIStackedLinearOperator`
         MPI Linear Operator to invert of size :math:`[N \times M]`
     y : :obj:`pylops_mpi.DistributedArray` or :obj:`pylops_mpi.StackedDistributedArray`
         DistributedArray of size (N,)
-    x0 : :obj:`pylops_mpi.DistributedArray` or :obj:`pylops_mpi.StackedDistributedArray`, optional
+    x0 : :obj:`pylops_mpi.DistributedArray` or :obj:`pylops_mpi.StackedDistributedArray`
         Initial guess
     niter : :obj:`int`, optional
         Number of iterations

--- a/tutorials/lsm.py
+++ b/tutorials/lsm.py
@@ -164,7 +164,10 @@ d_adj = d_adj_dist.asarray().reshape((nstot, nr, nt))
 # solver.
 
 # Inverse
-minv_dist = pylops_mpi.cgls(VStack, d_dist, niter=100, show=True)[0]
+# Initializing x0 to zeroes
+x0 = pylops_mpi.DistributedArray(VStack.shape[1], partition=pylops_mpi.Partition.BROADCAST)
+x0[:] = 0
+minv_dist = pylops_mpi.cgls(VStack, d_dist, x0=x0, niter=100, show=True)[0]
 minv = minv_dist.asarray().reshape((nx, nz))
 d_inv_dist = VStack @ minv_dist
 d_inv = d_inv_dist.asarray().reshape(nstot, nr, nt)


### PR DESCRIPTION
Closes #87 and #88 

- Add `base_comm` as a parameter to StackedDistributedArray(Required for cg/cgls, plus it is in all our ops, array)
- Removed code for `x0`, handle printing of steps/solvers.
- Change all the docstrings to support MPIStackedLinearOperator.
- In `lsm` and `plot_cgls`, handle initial guess `x0`.
- Update the tests for existing cg/cgls tests.
- Add new tests for StackedLinearOperators and StackedDistributedArray.