### PR TITLE
🚀 Enable use of cupy arrays

### DIFF
--- a/docs/source/gpu.rst
+++ b/docs/source/gpu.rst
@@ -1,0 +1,85 @@
+.. _gpu:
+
+GPU Support
+===========
+
+Overview
+--------
+PyLops-mpi supports computations on GPUs leveraging the GPU backend of PyLops. Under the hood,
+`CuPy <https://cupy.dev/>`_ (``cupy-cudaXX>=v13.0.0``) is used to perform all of the operations.
+This library must be installed *before* PyLops-mpi is installed.
+
+.. note::
+
+   Set environment variable ``CUPY_PYLOPS=0`` to force PyLops to ignore the ``cupy`` backend.
+   This can be also used if a previous (or faulty) version of ``cupy`` is installed in your system,
+   otherwise you will get an error when importing PyLops.
+
+
+The :class:`pylops_mpi.DistributedArray` and :class:`pylops_mpi.StackedDistributedArray` objects can be 
+generated using both ``numpy`` and ``cupy`` based local arrays, and all of the operators and solvers in PyLops-mpi 
+can handle both scenarios. Note that, since most operators in PyLops-mpi are thin-wrappers around PyLops operators,
+some of the operators in PyLops that lack a GPU implementation cannot be used also in PyLops-mpi when working with
+cupy arrays.
+
+
+Example
+-------
+
+Finally, let's briefly look at an example. First we write a code snippet using
+``numpy`` arrays which PyLops-mpi will run on your CPU:
+
+.. code-block:: python
+
+    # MPI helpers
+    comm = MPI.COMM_WORLD
+    rank = MPI.COMM_WORLD.Get_rank()
+    size = MPI.COMM_WORLD.Get_size()
+    
+    # Create distributed data (broadcast)
+    nxl, nt = 20, 20
+    dtype = np.float32
+    d_dist = pylops_mpi.DistributedArray(global_shape=nxl * nt,                                   
+                                         partition=pylops_mpi.Partition.BROADCAST,
+                                         engine="numpy", dtype=dtype)
+    d_dist[:] = np.ones(d_dist.local_shape, dtype=dtype)
+    
+    # Create and apply VStack operator
+    Sop = pylops.MatrixMult(np.ones((nxl, nxl)), otherdims=(nt, ))
+    HOp = pylops_mpi.MPIVStack(ops=[Sop, ])
+    y_dist = HOp @ d_dist
+    
+
+Now we write a code snippet using ``cupy`` arrays which PyLops will run on 
+your GPU:
+
+.. code-block:: python
+
+    # MPI helpers
+    comm = MPI.COMM_WORLD
+    rank = MPI.COMM_WORLD.Get_rank()
+    size = MPI.COMM_WORLD.Get_size()
+    
+    # Define gpu to use
+    cp.cuda.Device(device=rank).use()
+
+    # Create distributed data (broadcast)
+    nxl, nt = 20, 20
+    dtype = np.float32
+    d_dist = pylops_mpi.DistributedArray(global_shape=nxl * nt,                                   
+                                         partition=pylops_mpi.Partition.BROADCAST,
+                                         engine="cupy", dtype=dtype)
+    d_dist[:] = cp.ones(d_dist.local_shape, dtype=dtype)
+    
+    # Create and apply VStack operator
+    Sop = pylops.MatrixMult(cp.ones((nxl, nxl)), otherdims=(nt, ))
+    HOp = pylops_mpi.MPIVStack(ops=[Sop, ])
+    y_dist = HOp @ d_dist
+
+The code is almost unchanged apart from the fact that we now use ``cupy`` arrays,
+PyLops-mpi will figure this out!
+
+.. note::
+
+   The CuPy backend is in active development, with many examples not yet in the docs.
+   You can find many `other examples <https://github.com/PyLops/pylops_notebooks/tree/master/developement-mpi/Cupy_MPI>`_ from the `PyLops Notebooks repository <https://github.com/PyLops/pylops_notebooks>`_.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -71,6 +71,7 @@ class and implementing the ``_matvec`` and ``_rmatvec``.
 
     self
     installation.rst
+    gpu.rst
 
 .. toctree::
    :maxdepth: 2

--- a/examples/plot_stacked_array.py
+++ b/examples/plot_stacked_array.py
@@ -1,6 +1,6 @@
 """
 Stacked Array
-=========================
+=============
 This example shows how to use the :py:class:`pylops_mpi.StackedDistributedArray`.
 This class provides a way to combine and act on multiple :py:class:`pylops_mpi.DistributedArray`
 within the same program. This is very useful in scenarios where an array can be logically

--- a/pylops_mpi/DistributedArray.py
+++ b/pylops_mpi/DistributedArray.py
@@ -284,6 +284,7 @@ class DistributedArray:
             Axis of Distribution
         local_shapes : :obj:`list`, optional
             Local Shapes at each rank.
+        
         Returns
         ----------
         dist_array : :obj:`DistributedArray`

--- a/pylops_mpi/DistributedArray.py
+++ b/pylops_mpi/DistributedArray.py
@@ -535,6 +535,7 @@ class DistributedArray:
         arr = DistributedArray(global_shape=np.prod(self.global_shape),
                                local_shapes=local_shapes,
                                partition=self.partition,
+                               engine=self.engine,
                                dtype=self.dtype)
         local_array = np.ravel(self.local_array, order=order)
         x = local_array.copy()

--- a/pylops_mpi/DistributedArray.py
+++ b/pylops_mpi/DistributedArray.py
@@ -284,7 +284,7 @@ class DistributedArray:
             Axis of Distribution
         local_shapes : :obj:`list`, optional
             Local Shapes at each rank.
-        
+
         Returns
         ----------
         dist_array : :obj:`DistributedArray`

--- a/pylops_mpi/DistributedArray.py
+++ b/pylops_mpi/DistributedArray.py
@@ -5,7 +5,7 @@ from mpi4py import MPI
 from enum import Enum
 
 from pylops.utils import DTypeLike, NDArray
-from pylops.utils.backend import get_module
+from pylops.utils.backend import get_module, get_array_module, get_module_name
 
 
 class Partition(Enum):
@@ -294,6 +294,7 @@ class DistributedArray:
                                       partition=partition,
                                       axis=axis,
                                       local_shapes=local_shapes,
+                                      engine=get_module_name(get_array_module(x)),
                                       dtype=x.dtype)
         if partition == Partition.BROADCAST:
             dist_array[:] = x

--- a/pylops_mpi/LinearOperator.py
+++ b/pylops_mpi/LinearOperator.py
@@ -81,6 +81,7 @@ class MPILinearOperator:
                                  base_comm=self.base_comm,
                                  partition=x.partition,
                                  axis=x.axis,
+                                 engine=x.engine,
                                  dtype=self.dtype)
             y[:] = self.Op._matvec(x.local_array)
             return y
@@ -117,6 +118,7 @@ class MPILinearOperator:
                                  base_comm=self.base_comm,
                                  partition=x.partition,
                                  axis=x.axis,
+                                 engine=x.engine,
                                  dtype=self.dtype)
             y[:] = self.Op._rmatvec(x.local_array)
             return y

--- a/pylops_mpi/basicoperators/BlockDiag.py
+++ b/pylops_mpi/basicoperators/BlockDiag.py
@@ -121,7 +121,7 @@ class MPIBlockDiag(MPILinearOperator):
         for iop, oper in enumerate(self.ops):
             y1.append(oper.matvec(x.local_array[self.mmops[iop]:
                                                 self.mmops[iop + 1]]))
-        y[:] = ncp.concatenate(ncp.asarray(y1))
+        y[:] = ncp.concatenate(y1)
         return y
 
     @reshaped(forward=False, stacking=True)
@@ -133,7 +133,7 @@ class MPIBlockDiag(MPILinearOperator):
         for iop, oper in enumerate(self.ops):
             y1.append(oper.rmatvec(x.local_array[self.nnops[iop]:
                                                  self.nnops[iop + 1]]))
-        y[:] = ncp.concatenate(ncp.asarray(y1))
+        y[:] = ncp.concatenate(y1)
         return y
 
 

--- a/pylops_mpi/basicoperators/FirstDerivative.py
+++ b/pylops_mpi/basicoperators/FirstDerivative.py
@@ -2,8 +2,8 @@ from typing import Callable, Union
 import numpy as np
 from mpi4py import MPI
 
-from pylops.utils import DTypeLike
-from pylops.utils.typing import InputDimsLike
+from pylops.utils.backend import get_module
+from pylops.utils.typing import DTypeLike, InputDimsLike
 from pylops.utils._internal import _value_or_sized_to_tuple
 
 from pylops_mpi import (
@@ -140,17 +140,21 @@ class MPIFirstDerivative(MPILinearOperator):
 
     @reshaped
     def _matvec_forward(self, x: DistributedArray) -> DistributedArray:
-        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, axis=x.axis, dtype=self.dtype)
+        ncp = get_module(x.engine)
+        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, 
+                             axis=x.axis, engine=x.engine, dtype=self.dtype)
         ghosted_x = x.add_ghost_cells(cells_back=1)
         y_forward = ghosted_x[1:] - ghosted_x[:-1]
         if self.rank == self.size - 1:
-            y_forward = np.append(y_forward, np.zeros((1,) + self.dims[1:]), axis=0)
+            y_forward = ncp.append(y_forward, ncp.zeros((1,) + self.dims[1:]), axis=0)
         y[:] = y_forward / self.sampling
         return y
 
     @reshaped
     def _rmatvec_forward(self, x: DistributedArray) -> DistributedArray:
-        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, axis=x.axis, dtype=self.dtype)
+        ncp = get_module(x.engine)
+        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, 
+                             axis=x.axis, engine=x.engine, dtype=self.dtype)
         y[:] = 0
         if self.rank == self.size - 1:
             y[:-1] -= x[:-1]
@@ -159,29 +163,33 @@ class MPIFirstDerivative(MPILinearOperator):
         ghosted_x = x.add_ghost_cells(cells_front=1)
         y_forward = ghosted_x[:-1]
         if self.rank == 0:
-            y_forward = np.insert(y_forward, 0, np.zeros((1,) + self.dims[1:]), axis=0)
+            y_forward = ncp.append(ncp.zeros((1,) + self.dims[1:]), y_forward, axis=0)
         y[:] += y_forward
         y[:] /= self.sampling
         return y
 
     @reshaped
     def _matvec_backward(self, x: DistributedArray) -> DistributedArray:
-        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, axis=x.axis, dtype=self.dtype)
+        ncp = get_module(x.engine)
+        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, 
+                             axis=x.axis, engine=x.engine, dtype=self.dtype)
         ghosted_x = x.add_ghost_cells(cells_front=1)
         y_backward = ghosted_x[1:] - ghosted_x[:-1]
         if self.rank == 0:
-            y_backward = np.insert(y_backward, 0, np.zeros((1,) + self.dims[1:]), axis=0)
+            y_backward = ncp.append(ncp.zeros((1,) + self.dims[1:]), y_backward, axis=0)
         y[:] = y_backward / self.sampling
         return y
 
     @reshaped
     def _rmatvec_backward(self, x: DistributedArray) -> DistributedArray:
-        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, axis=x.axis, dtype=self.dtype)
+        ncp = get_module(x.engine)
+        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, 
+                             axis=x.axis, engine=x.engine, dtype=self.dtype)
         y[:] = 0
         ghosted_x = x.add_ghost_cells(cells_back=1)
         y_backward = ghosted_x[1:]
         if self.rank == self.size - 1:
-            y_backward = np.append(y_backward, np.zeros((1,) + self.dims[1:]), axis=0)
+            y_backward = ncp.append(y_backward, ncp.zeros((1,) + self.dims[1:]), axis=0)
         y[:] -= y_backward
         if self.rank == 0:
             y[1:] += x[1:]
@@ -192,13 +200,15 @@ class MPIFirstDerivative(MPILinearOperator):
 
     @reshaped
     def _matvec_centered3(self, x: DistributedArray) -> DistributedArray:
-        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, axis=x.axis, dtype=self.dtype)
+        ncp = get_module(x.engine)
+        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, 
+                             axis=x.axis, engine=x.engine, dtype=self.dtype)
         ghosted_x = x.add_ghost_cells(cells_front=1, cells_back=1)
         y_centered = 0.5 * (ghosted_x[2:] - ghosted_x[:-2])
         if self.rank == 0:
-            y_centered = np.insert(y_centered, 0, np.zeros((1,) + self.dims[1:]), axis=0)
+            y_centered = ncp.append(ncp.zeros((1,) + self.dims[1:]), y_centered, axis=0)
         if self.rank == self.size - 1:
-            y_centered = np.append(y_centered, np.zeros((min(y.global_shape[0] - 1, 1), ) + self.dims[1:]), axis=0)
+            y_centered = ncp.append(y_centered, ncp.zeros((min(y.global_shape[0] - 1, 1), ) + self.dims[1:]), axis=0)
         y[:] = y_centered
         if self.edge:
             if self.rank == 0:
@@ -210,18 +220,21 @@ class MPIFirstDerivative(MPILinearOperator):
 
     @reshaped
     def _rmatvec_centered3(self, x: DistributedArray) -> DistributedArray:
-        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, axis=x.axis, dtype=self.dtype)
+        ncp = get_module(x.engine)
+        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, 
+                             axis=x.axis, engine=x.engine, dtype=self.dtype)
         y[:] = 0
+
         ghosted_x = x.add_ghost_cells(cells_back=2)
         y_centered = 0.5 * ghosted_x[1:-1]
         if self.rank == self.size - 1:
-            y_centered = np.append(y_centered, np.zeros((min(y.global_shape[0], 2),) + self.dims[1:]), axis=0)
+            y_centered = ncp.append(y_centered, ncp.zeros((min(y.global_shape[0], 2),) + self.dims[1:]), axis=0)
         y[:] -= y_centered
 
         ghosted_x = x.add_ghost_cells(cells_front=2)
         y_centered = 0.5 * ghosted_x[1:-1]
         if self.rank == 0:
-            y_centered = np.insert(y_centered, 0, np.zeros((min(y.global_shape[0], 2),) + self.dims[1:]), axis=0)
+            y_centered = ncp.append(ncp.zeros((min(y.global_shape[0], 2),) + self.dims[1:]), y_centered, axis=0)
         y[:] += y_centered
         if self.edge:
             if self.rank == 0:
@@ -235,7 +248,9 @@ class MPIFirstDerivative(MPILinearOperator):
 
     @reshaped
     def _matvec_centered5(self, x: DistributedArray) -> DistributedArray:
-        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, axis=x.axis, dtype=self.dtype)
+        ncp = get_module(x.engine)
+        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, 
+                             axis=x.axis, engine=x.engine, dtype=self.dtype)
         ghosted_x = x.add_ghost_cells(cells_front=2, cells_back=2)
         y_centered = (
             ghosted_x[:-4] / 12.0
@@ -244,9 +259,9 @@ class MPIFirstDerivative(MPILinearOperator):
             - ghosted_x[4:] / 12.0
         )
         if self.rank == 0:
-            y_centered = np.insert(y_centered, 0, np.zeros((min(y.global_shape[0], 2),) + self.dims[1:]), axis=0)
+            y_centered = ncp.append(ncp.zeros((min(y.global_shape[0], 2),) + self.dims[1:]), y_centered, axis=0)
         if self.rank == self.size - 1:
-            y_centered = np.append(y_centered, np.zeros((min(y.global_shape[0] - 2, 2),) + self.dims[1:]), axis=0)
+            y_centered = ncp.append(y_centered, ncp.zeros((min(y.global_shape[0] - 2, 2),) + self.dims[1:]), axis=0)
         y[:] = y_centered
         if self.edge:
             if self.rank == 0:
@@ -260,34 +275,36 @@ class MPIFirstDerivative(MPILinearOperator):
 
     @reshaped
     def _rmatvec_centered5(self, x: DistributedArray) -> DistributedArray:
-        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, axis=x.axis, dtype=self.dtype)
+        ncp = get_module(x.engine)
+        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, 
+                             axis=x.axis, engine=x.engine, dtype=self.dtype)
         y[:] = 0
         ghosted_x = x.add_ghost_cells(cells_back=4)
         y_centered = ghosted_x[2:-2] / 12.0
         if self.rank == self.size - 1:
-            y_centered = np.append(y_centered, np.zeros((min(y.global_shape[0], 4),) + self.dims[1:]), axis=0)
+            y_centered = ncp.append(y_centered, ncp.zeros((min(y.global_shape[0], 4),) + self.dims[1:]), axis=0)
         y[:] += y_centered
 
         ghosted_x = x.add_ghost_cells(cells_front=1, cells_back=3)
         y_centered = 2.0 * ghosted_x[2:-2] / 3.0
         if self.rank == 0:
-            y_centered = np.insert(y_centered, 0, np.zeros((1,) + self.dims[1:]), axis=0)
+            y_centered = ncp.append(ncp.zeros((1,) + self.dims[1:]), y_centered, axis=0)
         if self.rank == self.size - 1:
-            y_centered = np.append(y_centered, np.zeros((min(y.global_shape[0] - 1, 3),) + self.dims[1:]), axis=0)
+            y_centered = ncp.append(y_centered, ncp.zeros((min(y.global_shape[0] - 1, 3),) + self.dims[1:]), axis=0)
         y[:] -= y_centered
 
         ghosted_x = x.add_ghost_cells(cells_front=3, cells_back=1)
         y_centered = 2.0 * ghosted_x[2:-2] / 3.0
         if self.rank == 0:
-            y_centered = np.insert(y_centered, 0, np.zeros((min(y.global_shape[0], 3),) + self.dims[1:]), axis=0)
+            y_centered = ncp.append(ncp.zeros((min(y.global_shape[0], 3),) + self.dims[1:]), y_centered, axis=0)
         if self.rank == self.size - 1:
-            y_centered = np.append(y_centered, np.zeros((min(y.global_shape[0] - 3, 1),) + self.dims[1:]), axis=0)
+            y_centered = ncp.append(y_centered, ncp.zeros((min(y.global_shape[0] - 3, 1),) + self.dims[1:]), axis=0)
         y[:] += y_centered
 
         ghosted_x = x.add_ghost_cells(cells_front=4)
         y_centered = ghosted_x[2:-2] / 12.0
         if self.rank == 0:
-            y_centered = np.insert(y_centered, 0, np.zeros((min(y.global_shape[0], 4),) + self.dims[1:]), axis=0)
+            y_centered = ncp.append(ncp.zeros((min(y.global_shape[0], 4),) + self.dims[1:]), y_centered, axis=0)
         y[:] -= y_centered
         if self.edge:
             if self.rank == 0:

--- a/pylops_mpi/basicoperators/FirstDerivative.py
+++ b/pylops_mpi/basicoperators/FirstDerivative.py
@@ -141,7 +141,7 @@ class MPIFirstDerivative(MPILinearOperator):
     @reshaped
     def _matvec_forward(self, x: DistributedArray) -> DistributedArray:
         ncp = get_module(x.engine)
-        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, 
+        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes,
                              axis=x.axis, engine=x.engine, dtype=self.dtype)
         ghosted_x = x.add_ghost_cells(cells_back=1)
         y_forward = ghosted_x[1:] - ghosted_x[:-1]
@@ -153,7 +153,7 @@ class MPIFirstDerivative(MPILinearOperator):
     @reshaped
     def _rmatvec_forward(self, x: DistributedArray) -> DistributedArray:
         ncp = get_module(x.engine)
-        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, 
+        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes,
                              axis=x.axis, engine=x.engine, dtype=self.dtype)
         y[:] = 0
         if self.rank == self.size - 1:
@@ -171,8 +171,8 @@ class MPIFirstDerivative(MPILinearOperator):
     @reshaped
     def _matvec_backward(self, x: DistributedArray) -> DistributedArray:
         ncp = get_module(x.engine)
-        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, 
-                             axis=x.axis, engine=x.engine, dtype=self.dtype)
+        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes,
+                            axis=x.axis, engine=x.engine, dtype=self.dtype)
         ghosted_x = x.add_ghost_cells(cells_front=1)
         y_backward = ghosted_x[1:] - ghosted_x[:-1]
         if self.rank == 0:
@@ -183,7 +183,7 @@ class MPIFirstDerivative(MPILinearOperator):
     @reshaped
     def _rmatvec_backward(self, x: DistributedArray) -> DistributedArray:
         ncp = get_module(x.engine)
-        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, 
+        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes,
                              axis=x.axis, engine=x.engine, dtype=self.dtype)
         y[:] = 0
         ghosted_x = x.add_ghost_cells(cells_back=1)
@@ -201,7 +201,7 @@ class MPIFirstDerivative(MPILinearOperator):
     @reshaped
     def _matvec_centered3(self, x: DistributedArray) -> DistributedArray:
         ncp = get_module(x.engine)
-        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, 
+        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes,
                              axis=x.axis, engine=x.engine, dtype=self.dtype)
         ghosted_x = x.add_ghost_cells(cells_front=1, cells_back=1)
         y_centered = 0.5 * (ghosted_x[2:] - ghosted_x[:-2])
@@ -221,7 +221,7 @@ class MPIFirstDerivative(MPILinearOperator):
     @reshaped
     def _rmatvec_centered3(self, x: DistributedArray) -> DistributedArray:
         ncp = get_module(x.engine)
-        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, 
+        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes,
                              axis=x.axis, engine=x.engine, dtype=self.dtype)
         y[:] = 0
 
@@ -249,7 +249,7 @@ class MPIFirstDerivative(MPILinearOperator):
     @reshaped
     def _matvec_centered5(self, x: DistributedArray) -> DistributedArray:
         ncp = get_module(x.engine)
-        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, 
+        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes,
                              axis=x.axis, engine=x.engine, dtype=self.dtype)
         ghosted_x = x.add_ghost_cells(cells_front=2, cells_back=2)
         y_centered = (
@@ -276,7 +276,7 @@ class MPIFirstDerivative(MPILinearOperator):
     @reshaped
     def _rmatvec_centered5(self, x: DistributedArray) -> DistributedArray:
         ncp = get_module(x.engine)
-        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, 
+        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes,
                              axis=x.axis, engine=x.engine, dtype=self.dtype)
         y[:] = 0
         ghosted_x = x.add_ghost_cells(cells_back=4)

--- a/pylops_mpi/basicoperators/FirstDerivative.py
+++ b/pylops_mpi/basicoperators/FirstDerivative.py
@@ -172,7 +172,7 @@ class MPIFirstDerivative(MPILinearOperator):
     def _matvec_backward(self, x: DistributedArray) -> DistributedArray:
         ncp = get_module(x.engine)
         y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes,
-                            axis=x.axis, engine=x.engine, dtype=self.dtype)
+                             axis=x.axis, engine=x.engine, dtype=self.dtype)
         ghosted_x = x.add_ghost_cells(cells_front=1)
         y_backward = ghosted_x[1:] - ghosted_x[:-1]
         if self.rank == 0:

--- a/pylops_mpi/basicoperators/SecondDerivative.py
+++ b/pylops_mpi/basicoperators/SecondDerivative.py
@@ -2,6 +2,7 @@ from typing import Callable, Union
 import numpy as np
 from mpi4py import MPI
 
+from pylops.utils.backend import get_module
 from pylops.utils.typing import DTypeLike, InputDimsLike
 from pylops.utils._internal import _value_or_sized_to_tuple
 
@@ -122,16 +123,19 @@ class MPISecondDerivative(MPILinearOperator):
 
     @reshaped
     def _matvec_forward(self, x: DistributedArray) -> DistributedArray:
-        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, axis=x.axis, dtype=self.dtype)
+        ncp = get_module(x.engine)
+        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes,
+                             axis=x.axis, engine=x.engine, dtype=self.dtype)
         ghosted_x = x.add_ghost_cells(cells_back=2)
         y_forward = ghosted_x[2:] - 2 * ghosted_x[1:-1] + ghosted_x[:-2]
         if self.rank == self.size - 1:
-            y_forward = np.append(y_forward, np.zeros((min(y.global_shape[0], 2),) + self.dims[1:]), axis=0)
+            y_forward = ncp.append(y_forward, ncp.zeros((min(y.global_shape[0], 2),) + self.dims[1:]), axis=0)
         y[:] = y_forward / self.sampling ** 2
         return y
 
     @reshaped
     def _rmatvec_forward(self, x: DistributedArray) -> DistributedArray:
+        ncp = get_module(x.engine)
         y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, axis=x.axis, dtype=self.dtype)
         y[:] = 0
         if self.rank == self.size - 1:
@@ -142,45 +146,49 @@ class MPISecondDerivative(MPILinearOperator):
         ghosted_x = x.add_ghost_cells(cells_front=1, cells_back=1)
         y_forward = ghosted_x[:-2]
         if self.rank == 0:
-            y_forward = np.insert(y_forward, 0, np.zeros((1,) + self.dims[1:]), axis=0)
+            y_forward = ncp.append(ncp.zeros((1,) + self.dims[1:]), y_forward, axis=0)
         if self.rank == self.size - 1:
-            y_forward = np.append(y_forward, np.zeros((min(1, y.global_shape[0] - 1),) + self.dims[1:]), axis=0)
+            y_forward = ncp.append(y_forward, ncp.zeros((min(1, y.global_shape[0] - 1),) + self.dims[1:]), axis=0)
         y[:] -= 2 * y_forward
 
         ghosted_x = x.add_ghost_cells(cells_front=2)
         y_forward = ghosted_x[:-2]
         if self.rank == 0:
-            y_forward = np.insert(y_forward, 0, np.zeros((min(y.global_shape[0], 2),) + self.dims[1:]), axis=0)
+            y_forward = ncp.append(ncp.zeros((min(y.global_shape[0], 2),) + self.dims[1:]), y_forward, axis=0)
         y[:] += y_forward
         y[:] /= self.sampling ** 2
         return y
 
     @reshaped
     def _matvec_backward(self, x: DistributedArray) -> DistributedArray:
-        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, axis=x.axis, dtype=self.dtype)
+        ncp = get_module(x.engine)
+        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes,
+                             axis=x.axis, engine=x.engine, dtype=self.dtype)
         ghosted_x = x.add_ghost_cells(cells_front=2)
         y_backward = ghosted_x[2:] - 2 * ghosted_x[1:-1] + ghosted_x[:-2]
         if self.rank == 0:
-            y_backward = np.insert(y_backward, 0, np.zeros((min(y.global_shape[0], 2),) + self.dims[1:]), axis=0)
+            y_backward = ncp.append(ncp.zeros((min(y.global_shape[0], 2),) + self.dims[1:]), y_backward, axis=0)
         y[:] = y_backward / self.sampling ** 2
         return y
 
     @reshaped
     def _rmatvec_backward(self, x: DistributedArray) -> DistributedArray:
-        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, axis=x.axis, dtype=self.dtype)
+        ncp = get_module(x.engine)
+        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes,
+                             axis=x.axis, engine=x.engine, dtype=self.dtype)
         y[:] = 0
         ghosted_x = x.add_ghost_cells(cells_back=2)
         y_backward = ghosted_x[2:]
         if self.rank == self.size - 1:
-            y_backward = np.append(y_backward, np.zeros((min(2, y.global_shape[0]),) + self.dims[1:]), axis=0)
+            y_backward = ncp.append(y_backward, ncp.zeros((min(2, y.global_shape[0]),) + self.dims[1:]), axis=0)
         y[:] += y_backward
 
         ghosted_x = x.add_ghost_cells(cells_front=1, cells_back=1)
         y_backward = 2 * ghosted_x[2:]
         if self.rank == 0:
-            y_backward = np.insert(y_backward, 0, np.zeros((1,) + self.dims[1:]), axis=0)
+            y_backward = ncp.append(ncp.zeros((1,) + self.dims[1:]), y_backward, axis=0)
         if self.rank == self.size - 1:
-            y_backward = np.append(y_backward, np.zeros((min(1, y.global_shape[0] - 1),) + self.dims[1:]), axis=0)
+            y_backward = ncp.append(y_backward, ncp.zeros((min(1, y.global_shape[0] - 1),) + self.dims[1:]), axis=0)
         y[:] -= y_backward
 
         if self.rank == 0:
@@ -192,13 +200,15 @@ class MPISecondDerivative(MPILinearOperator):
 
     @reshaped
     def _matvec_centered(self, x: DistributedArray) -> DistributedArray:
-        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, axis=x.axis, dtype=self.dtype)
+        ncp = get_module(x.engine)
+        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes,
+                             axis=x.axis, engine=x.engine, dtype=self.dtype)
         ghosted_x = x.add_ghost_cells(cells_front=1, cells_back=1)
         y_centered = ghosted_x[2:] - 2 * ghosted_x[1:-1] + ghosted_x[:-2]
         if self.rank == 0:
-            y_centered = np.insert(y_centered, 0, np.zeros((1,) + self.dims[1:]), axis=0)
+            y_centered = ncp.append(ncp.zeros((1,) + self.dims[1:]), y_centered, axis=0)
         if self.rank == self.size - 1:
-            y_centered = np.append(y_centered, np.zeros((min(1, y.global_shape[0] - 1),) + self.dims[1:]), axis=0)
+            y_centered = ncp.append(y_centered, ncp.zeros((min(1, y.global_shape[0] - 1),) + self.dims[1:]), axis=0)
         y[:] = y_centered
         if self.edge:
             if self.rank == 0:
@@ -210,26 +220,28 @@ class MPISecondDerivative(MPILinearOperator):
 
     @reshaped
     def _rmatvec_centered(self, x: DistributedArray) -> DistributedArray:
-        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes, axis=x.axis, dtype=self.dtype)
+        ncp = get_module(x.engine)
+        y = DistributedArray(global_shape=x.global_shape, local_shapes=x.local_shapes,
+                             axis=x.axis, engine=x.engine, dtype=self.dtype)
         y[:] = 0
         ghosted_x = x.add_ghost_cells(cells_back=2)
         y_centered = ghosted_x[1:-1]
         if self.rank == self.size - 1:
-            y_centered = np.append(y_centered, np.zeros((min(2, y.global_shape[0]),) + self.dims[1:]), axis=0)
+            y_centered = ncp.append(y_centered, ncp.zeros((min(2, y.global_shape[0]),) + self.dims[1:]), axis=0)
         y[:] += y_centered
 
         ghosted_x = x.add_ghost_cells(cells_front=1, cells_back=1)
         y_centered = 2 * ghosted_x[1:-1]
         if self.rank == 0:
-            y_centered = np.insert(y_centered, 0, np.zeros((1,) + self.dims[1:]), axis=0)
+            y_centered = ncp.append(ncp.zeros((1,) + self.dims[1:]), y_centered, axis=0)
         if self.rank == self.size - 1:
-            y_centered = np.append(y_centered, np.zeros((min(1, y.global_shape[0] - 1),) + self.dims[1:]), axis=0)
+            y_centered = ncp.append(y_centered, ncp.zeros((min(1, y.global_shape[0] - 1),) + self.dims[1:]), axis=0)
         y[:] -= y_centered
 
         ghosted_x = x.add_ghost_cells(cells_front=2)
         y_centered = ghosted_x[1:-1]
         if self.rank == 0:
-            y_centered = np.insert(y_centered, 0, np.zeros((min(2, y.global_shape[0]),) + self.dims[1:]), axis=0)
+            y_centered = ncp.append(ncp.zeros((min(2, y.global_shape[0]),) + self.dims[1:]), y_centered, axis=0)
         y[:] += y_centered
         if self.edge:
             if self.rank == 0:

--- a/pylops_mpi/basicoperators/VStack.py
+++ b/pylops_mpi/basicoperators/VStack.py
@@ -136,7 +136,7 @@ class MPIVStack(MPILinearOperator):
         y1 = []
         for iop, oper in enumerate(self.ops):
             y1.append(oper.rmatvec(x.local_array[self.nnops[iop]: self.nnops[iop + 1]]))
-        y1 = ncp.sum(ncp.asarray(y1), axis=0)
+        y1 = ncp.sum(y1, axis=0)
         y[:] = self.base_comm.allreduce(y1, op=MPI.SUM)
         return y
 

--- a/pylops_mpi/optimization/cls_basic.py
+++ b/pylops_mpi/optimization/cls_basic.py
@@ -337,7 +337,7 @@ class CGLS(Solver):
         self.rank = x.rank
         self.c = r.copy()
         self.q = self.Op.matvec(self.c)
-        self.kold = np.abs(r.dot(r.conj()))
+        self.kold = float(np.abs(r.dot(r.conj())))
 
         # create variables to track the residual norm and iterations
         self.cost = []
@@ -373,13 +373,13 @@ class CGLS(Solver):
 
         """
 
-        a = self.kold / (self.q.dot(self.q.conj()) + self.damp * self.c.dot(self.c.conj()))
+        a = float(self.kold / (self.q.dot(self.q.conj()) + self.damp * self.c.dot(self.c.conj())))
         x += a * self.c
         self.s -= a * self.q
         damped_x = self.damp * x
         r = self.Op.rmatvec(self.s) - damped_x
-        k = np.abs(r.dot(r.conj()))
-        b = k / self.kold
+        k = float(np.abs(r.dot(r.conj())))
+        b = float(k / self.kold)
         self.c = r + b * self.c
         self.q = self.Op.matvec(self.c)
         self.kold = k

--- a/pylops_mpi/optimization/cls_basic.py
+++ b/pylops_mpi/optimization/cls_basic.py
@@ -86,7 +86,7 @@ class CG(Solver):
         self.r = self.y - self.Op.matvec(x)
         self.rank = x.rank
         self.c = self.r.copy()
-        self.kold = np.abs(self.r.dot(self.r.conj()))
+        self.kold = float(np.abs(self.r.dot(self.r.conj())))
 
         # create variables to track the residual norm and iterations
         self.cost: List = []
@@ -120,11 +120,11 @@ class CG(Solver):
         """
         Opc = self.Op.matvec(self.c)
         cOpc = np.abs(self.c.dot(Opc.conj()))
-        a = self.kold / cOpc
+        a = float(self.kold / cOpc)
         x += a * self.c
         self.r -= a * Opc
-        k = np.abs(self.r.dot(self.r.conj()))
-        b = k / self.kold
+        k = float(np.abs(self.r.dot(self.r.conj())))
+        b = float(k / self.kold)
         self.c = self.r + b * self.c
         self.kold = k
         self.iiter += 1

--- a/pylops_mpi/utils/decorators.py
+++ b/pylops_mpi/utils/decorators.py
@@ -54,7 +54,8 @@ def reshaped(
                 local_shapes = None
                 global_shape = getattr(self, "dims")
             arr = DistributedArray(global_shape=global_shape,
-                                   local_shapes=local_shapes, axis=0, dtype=x.dtype)
+                                   local_shapes=local_shapes, axis=0, 
+                                   engine=x.engine, dtype=x.dtype)
             arr_local_shapes = np.asarray(arr.base_comm.allgather(np.prod(arr.local_shape)))
             x_local_shapes = np.asarray(x.base_comm.allgather(np.prod(x.local_shape)))
             # Calculate num_ghost_cells required for each rank


### PR DESCRIPTION
# Motivation
This PR is aimed at extending the capabilities of PyLops-MPI to use of CuPy arrays. This is powered by most of the same routines used in PyLops's CuPy backend.

# Objective
Following https://github.com/PyLops/pylops-mpi/issues/99, we want to explore the combined use of MPI4py and CuPy to allow creating distributed arrays with locals stored on GPUs and direct communication (without passing from CPU). So far, only minimal changes seem to allow this - see notebooks at https://github.com/PyLops/pylops_notebooks/tree/master/developement-mpi/Cupy_MPI