### PR TITLE
Fix datatypes for macos test fails

### DIFF
--- a/tests/test_derivative.py
+++ b/tests/test_derivative.py
@@ -14,7 +14,7 @@ par1 = {
     "nz": 600,
     "dz": 1.0,
     "edge": False,
-    "dtype": np.float128,
+    "dtype": np.float64,
     "partition": pylops_mpi.Partition.SCATTER
 }
 
@@ -22,7 +22,7 @@ par1b = {
     "nz": 600,
     "dz": 1.0,
     "edge": False,
-    "dtype": np.float128,
+    "dtype": np.float64,
     "partition": pylops_mpi.Partition.BROADCAST
 }
 
@@ -30,7 +30,7 @@ par1j = {
     "nz": 600,
     "dz": 1.0,
     "edge": False,
-    "dtype": np.complex256,
+    "dtype": np.complex128,
     "partition": pylops_mpi.Partition.SCATTER
 }
 
@@ -38,7 +38,7 @@ par1e = {
     "nz": 600,
     "dz": 1.0,
     "edge": True,
-    "dtype": np.float128,
+    "dtype": np.float64,
     "partition": pylops_mpi.Partition.SCATTER
 }
 
@@ -46,7 +46,7 @@ par2 = {
     "nz": (100, 151),
     "dz": 1.0,
     "edge": False,
-    "dtype": np.float128,
+    "dtype": np.float64,
     "partition": pylops_mpi.Partition.SCATTER
 }
 
@@ -54,7 +54,7 @@ par2b = {
     "nz": (100, 151),
     "dz": 1.0,
     "edge": False,
-    "dtype": np.float128,
+    "dtype": np.float64,
     "partition": pylops_mpi.Partition.BROADCAST
 }
 
@@ -62,7 +62,7 @@ par2j = {
     "nz": (100, 151),
     "dz": 1.0,
     "edge": False,
-    "dtype": np.complex256,
+    "dtype": np.complex128,
     "partition": pylops_mpi.Partition.SCATTER
 }
 
@@ -70,7 +70,7 @@ par2e = {
     "nz": (100, 151),
     "dz": 1.0,
     "edge": True,
-    "dtype": np.float128,
+    "dtype": np.float64,
     "partition": pylops_mpi.Partition.SCATTER
 }
 
@@ -78,7 +78,7 @@ par3 = {
     "nz": (101, 51, 100),
     "dz": 0.4,
     "edge": False,
-    "dtype": np.float128,
+    "dtype": np.float64,
     "partition": pylops_mpi.Partition.SCATTER
 }
 
@@ -86,7 +86,7 @@ par3b = {
     "nz": (101, 51, 100),
     "dz": 0.4,
     "edge": False,
-    "dtype": np.float128,
+    "dtype": np.float64,
     "partition": pylops_mpi.Partition.BROADCAST
 }
 
@@ -94,7 +94,7 @@ par3j = {
     "nz": (101, 51, 100),
     "dz": 0.4,
     "edge": True,
-    "dtype": np.complex256,
+    "dtype": np.complex128,
     "partition": pylops_mpi.Partition.SCATTER
 }
 
@@ -102,7 +102,7 @@ par3e = {
     "nz": (101, 51, 100),
     "dz": 0.4,
     "edge": True,
-    "dtype": np.float128,
+    "dtype": np.float64,
     "partition": pylops_mpi.Partition.SCATTER
 }
 
@@ -110,7 +110,7 @@ par4 = {
     "nz": (79, 101, 50),
     "dz": 0.4,
     "edge": False,
-    "dtype": np.float128,
+    "dtype": np.float64,
     "partition": pylops_mpi.Partition.SCATTER
 }
 
@@ -118,7 +118,7 @@ par4b = {
     "nz": (79, 101, 50),
     "dz": 0.4,
     "edge": False,
-    "dtype": np.float128,
+    "dtype": np.float64,
     "partition": pylops_mpi.Partition.BROADCAST
 }
 
@@ -126,7 +126,7 @@ par4j = {
     "nz": (79, 101, 50),
     "dz": 0.4,
     "edge": True,
-    "dtype": np.complex256,
+    "dtype": np.complex128,
     "partition": pylops_mpi.Partition.SCATTER
 }
 
@@ -134,7 +134,7 @@ par4e = {
     "nz": (79, 101, 50),
     "dz": 0.4,
     "edge": True,
-    "dtype": np.float128,
+    "dtype": np.float64,
     "partition": pylops_mpi.Partition.SCATTER
 }
 
@@ -144,7 +144,7 @@ par5 = {
     "weights": (0.7, 0.7, 0.7),
     "sampling": (1, 1, 1),
     "edge": False,
-    "dtype": np.float128,
+    "dtype": np.float64,
 }
 
 par5e = {
@@ -153,7 +153,7 @@ par5e = {
     "weights": (0.7, 0.7, 0.7),
     "sampling": (1, 1, 1),
     "edge": True,
-    "dtype": np.float128,
+    "dtype": np.float64,
 }
 
 par6 = {
@@ -162,7 +162,7 @@ par6 = {
     "weights": (1, 1, 1),
     "sampling": (0.4, 0.4, 0.4),
     "edge": False,
-    "dtype": np.float128,
+    "dtype": np.float64,
 }
 
 par6e = {
@@ -171,7 +171,7 @@ par6e = {
     "weights": (1, 1, 1),
     "sampling": (0.4, 0.4, 0.4),
     "edge": True,
-    "dtype": np.float128,
+    "dtype": np.float64,
 }
 
 

--- a/tests/test_distributedarray.py
+++ b/tests/test_distributedarray.py
@@ -191,4 +191,4 @@ def test_distributed_norm(par):
                     np.linalg.norm(par['x'], ord=1, axis=par['axis']), rtol=1e-14)
     assert_allclose(arr.norm(ord=np.inf, axis=par['axis']),
                     np.linalg.norm(par['x'], ord=np.inf, axis=par['axis']), rtol=1e-14)
-    assert_allclose(arr.norm(), np.linalg.norm(par['x'].flatten()), rtol=1e-14)
+    assert_allclose(arr.norm(), np.linalg.norm(par['x'].flatten()), rtol=1e-13)

--- a/tests/test_linearop.py
+++ b/tests/test_linearop.py
@@ -18,10 +18,10 @@ np.random.seed(42)
 rank = MPI.COMM_WORLD.Get_rank()
 size = MPI.COMM_WORLD.Get_size()
 
-par1 = {'ny': 101, 'nx': 101, 'dtype': np.float128}
-par1j = {'ny': 101, 'nx': 101, 'dtype': np.complex256}
-par2 = {'ny': 301, 'nx': 101, 'dtype': np.float128}
-par2j = {'ny': 301, 'nx': 101, 'dtype': np.complex256}
+par1 = {'ny': 101, 'nx': 101, 'dtype': np.float64}
+par1j = {'ny': 101, 'nx': 101, 'dtype': np.complex128}
+par2 = {'ny': 301, 'nx': 101, 'dtype': np.float64}
+par2j = {'ny': 301, 'nx': 101, 'dtype': np.complex128}
 
 
 @pytest.mark.mpi(min_size=2)

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -31,56 +31,56 @@ par1 = {
     "nx": 11,
     "imag": 0,
     "x0": False,
-    "dtype": "float128",
+    "dtype": "float64",
 }  # square real, zero initial guess
 par2 = {
     "ny": 11,
     "nx": 11,
     "imag": 0,
     "x0": True,
-    "dtype": "float128",
+    "dtype": "float64",
 }  # square real, non-zero initial guess
 par3 = {
     "ny": 31,
     "nx": 11,
     "imag": 0,
     "x0": False,
-    "dtype": "float128",
+    "dtype": "float64",
 }  # overdetermined real, zero initial guess
 par4 = {
     "ny": 31,
     "nx": 11,
     "imag": 0,
     "x0": True,
-    "dtype": "float128",
+    "dtype": "float64",
 }  # overdetermined real, non-zero initial guess
 par1j = {
     "ny": 11,
     "nx": 11,
     "imag": 1j,
     "x0": False,
-    "dtype": "complex256",
+    "dtype": "complex128",
 }  # square complex, zero initial guess
 par2j = {
     "ny": 11,
     "nx": 11,
     "imag": 1j,
     "x0": True,
-    "dtype": "complex256",
+    "dtype": "complex128",
 }  # square complex, non-zero initial guess
 par3j = {
     "ny": 31,
     "nx": 11,
     "imag": 1j,
     "x0": False,
-    "dtype": "complex256",
+    "dtype": "complex128",
 }  # overdetermined complex, zero initial guess
 par4j = {
     "ny": 31,
     "nx": 11,
     "imag": 1j,
     "x0": True,
-    "dtype": "complex256",
+    "dtype": "complex128",
 }  # overdetermined complex, non-zero initial guess
 
 
@@ -268,7 +268,7 @@ def test_cgls_broadcastmodel(par):
             x0 = None
         y1 = Vstack @ x_global
         xinv1 = pylops.cgls(Vstack, y1, x0=x0, niter=par["nx"], tol=1e-5, show=True)[0]
-        assert_allclose(xinv_array, xinv1, rtol=1e-14)
+        assert_allclose(xinv_array, xinv1, rtol=1e-13)
 
 
 @pytest.mark.mpi(min_size=2)

--- a/tests/test_stackedlinearop.py
+++ b/tests/test_stackedlinearop.py
@@ -11,10 +11,10 @@ np.random.seed(42)
 rank = MPI.COMM_WORLD.Get_rank()
 size = MPI.COMM_WORLD.Get_size()
 
-par1 = {'ny': 101, 'nx': 101, 'dtype': np.float128}
-par1j = {'ny': 101, 'nx': 101, 'dtype': np.complex256}
-par2 = {'ny': 301, 'nx': 101, 'dtype': np.float128}
-par2j = {'ny': 301, 'nx': 101, 'dtype': np.complex256}
+par1 = {'ny': 101, 'nx': 101, 'dtype': np.float64}
+par1j = {'ny': 101, 'nx': 101, 'dtype': np.complex128}
+par2 = {'ny': 301, 'nx': 101, 'dtype': np.float64}
+par2j = {'ny': 301, 'nx': 101, 'dtype': np.complex128}
 
 
 @pytest.mark.mpi(min_size=2)


### PR DESCRIPTION
Closes #101 
- Change `np.float128` to `np.float64` in tests.
- Change `np.complex256` to `np.complex128` in tests.
- Minor change of rtol to 1e-13 