### PR TITLE
Test for numpy>=2.0.0

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,10 +5,10 @@ channels:
 dependencies:
   - python >= 3.8.0
   - pip
-  - numpy>=1.21.0
+  - numpy
   - scipy>=1.8.0
   - mpi4py
-  - pylops >= 2.0
+  - pylops
   - matplotlib
   - ipython
   - pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
-numpy>=1.21.0, <2.0.0
+numpy
 scipy>=1.8.0
-pylops>=2.0
+pylops
 mpi4py
 matplotlib
 pytest


### PR DESCRIPTION
Closes #105 
- With the new version of PyLops released, testing for `numpy >=2.0.0`