### PR TITLE
Change Array assignment for Broadcast 

### DIFF
--- a/pylops_mpi/DistributedArray.py
+++ b/pylops_mpi/DistributedArray.py
@@ -130,10 +130,7 @@ class DistributedArray:
             Represents the value that will be assigned to the local array at
             the specified index positions.
         """
-        if self.partition is Partition.BROADCAST:
-            self.local_array[index] = self.base_comm.bcast(value)
-        else:
-            self.local_array[index] = value
+        self.local_array[index] = value
 
     @property
     def global_shape(self):


### PR DESCRIPTION
Fixes #115 
- Instead of using bcast, directly assign to local array