### PR TITLE
Fix how NCCL existence is checked 

### DIFF
--- a/pylops_mpi/utils/deps.py
+++ b/pylops_mpi/utils/deps.py
@@ -3,7 +3,7 @@ __all__ = [
 ]
 
 import os
-from importlib import import_module, util
+from importlib import util
 from typing import Optional
 
 
@@ -23,10 +23,10 @@ def nccl_import(message: Optional[str] = None) -> str:
         else:
             # if unable to import but the package is installed
             nccl_message = (
-                        f"cupy is installed but cupy.cuda.nccl not available, Falling back to pure MPI."
-                        "Please ensure your CUDA NCCL environment is set up correctly "
-                        "for more details visit 'https://docs.cupy.dev/en/stable/install.html'"
-                    )
+                "cupy is installed but cupy.cuda.nccl not available, Falling back to pure MPI."
+                "Please ensure your CUDA NCCL environment is set up correctly "
+                "for more details visit 'https://docs.cupy.dev/en/stable/install.html'"
+            )
             print(UserWarning(nccl_message))
     else:
         nccl_message = (


### PR DESCRIPTION
The bug is discovered by @mrava87  when the system is installed with CuPy but without NCCL.

Scenario:
CuPy always comes with `cupy.cuda.nccl` so checking the import error of `cupy.cuda.nccl` is not sufficient to verify the existence of NCCL. Under the original code, with CuPy installed without NCCL, the `deps.nccl_enabled` will be `True` (as no import error occurs).  This will lead to crash `import pylops_mpi` because it can't find nccl.NCCL_FLOAT32

Fix:
If CuPy is present, this import statement `import cupy.cuda.nccl as nccl` will not throw an error and we can check the NCCL's existence through this `nccl.available` flag


