### PR TITLE
feat: added masked option to asarray

### DIFF
--- a/examples/plot_distributed_array.py
+++ b/examples/plot_distributed_array.py
@@ -140,6 +140,11 @@ x = pylops_mpi.DistributedArray(global_shape=global_shape,
                                 mask=mask)
 x[:] = (MPI.COMM_WORLD.Get_rank() % subsize + 1.) * np.ones(local_shape)
 xloc = x.asarray()
+xloc1 = x.asarray(masked=True)
+
+if rank == 0:
+    print('xloc (with repeated portions)', xloc)
+    print('xloc (only effective portions):', xloc1)
 
 # Dot product
 dot = x.dot(x)

--- a/pylops_mpi/DistributedArray.py
+++ b/pylops_mpi/DistributedArray.py
@@ -359,10 +359,15 @@ class DistributedArray:
         """
         return self._sub_comm
 
-    def asarray(self):
+    def asarray(self, masked: bool = False):
         """Global view of the array
 
-        Gather all the local arrays
+        Gather all the local arrays from base communicator or subcommunicator
+
+        Parameters
+        ----------
+        masked : :obj:`bool`
+            Return local arrays of the subcommunicator (`True`) or base communicator (`False`).
 
         Returns
         -------
@@ -375,10 +380,14 @@ class DistributedArray:
             return self.local_array
 
         if deps.nccl_enabled and getattr(self, "base_comm_nccl"):
-            return nccl_asarray(self.base_comm_nccl, self.local_array, self.local_shapes, self.axis)
+            return nccl_asarray(self.sub_comm if masked else self.base_comm,
+                                self.local_array, self.local_shapes, self.axis)
         else:
             # Gather all the local arrays and apply concatenation.
-            final_array = self._allgather(self.local_array)
+            if masked:
+                final_array = self._allgather_subcomm(self.local_array)
+            else:
+                final_array = self._allgather(self.local_array)
             return np.concatenate(final_array, axis=self.axis)
 
     @classmethod
@@ -501,6 +510,17 @@ class DistributedArray:
             if recv_buf is None:
                 return self.base_comm.allgather(send_buf)
             self.base_comm.Allgather(send_buf, recv_buf)
+            return recv_buf
+
+    def _allgather_subcomm(self, send_buf, recv_buf=None):
+        """Allgather operation with subcommunicator
+        """
+        if deps.nccl_enabled and getattr(self, "base_comm_nccl"):
+            return nccl_allgather(self.sub_comm, send_buf, recv_buf)
+        else:
+            if recv_buf is None:
+                return self.sub_comm.allgather(send_buf)
+            self.sub_comm.Allgather(send_buf, recv_buf)
             return recv_buf
 
     def __neg__(self):


### PR DESCRIPTION
This PR adds a new optional input to the `DistributedArray.asarray` method called `masked`, which can be used with distributed arrays that have a `mask` to create a global view of the distributed array that contains only elements from one color of the mask (so that repeated portions of the array are not returned).