### PR TITLE
Complex-number Support for NCCL & Fredholm NCCL

### DIFF
--- a/docs/source/gpu.rst
+++ b/docs/source/gpu.rst
@@ -153,8 +153,8 @@ In the following, we provide a list of modules (i.e., operators and solvers) whe
    * - :class:`pylops_mpi.optimization.basic.cgls`
      - ✅ 
    * - :class:`pylops_mpi.signalprocessing.Fredhoml1`
-     - Planned ⏳
+     - ✅ 
+   * - Complex Numeric Data Type for NCCL 
+     - ✅ 
    * - ISTA Solver
      - Planned ⏳
-   * - Complex Numeric Data Type for NCCL 
-     - Planned ⏳ 

--- a/pylops_mpi/DistributedArray.py
+++ b/pylops_mpi/DistributedArray.py
@@ -14,7 +14,7 @@ cupy_message = pylops_deps.cupy_import("the DistributedArray module")
 nccl_message = deps.nccl_import("the DistributedArray module")
 
 if nccl_message is None and cupy_message is None:
-    from pylops_mpi.utils._nccl import nccl_allgather, nccl_allreduce, nccl_asarray, nccl_bcast, nccl_split, nccl_send, nccl_recv
+    from pylops_mpi.utils._nccl import nccl_allgather, nccl_allreduce, nccl_asarray, nccl_bcast, nccl_split, nccl_send, nccl_recv, _prepare_nccl_allgather_inputs, _unroll_nccl_allgather_recv
     from cupy.cuda.nccl import NcclCommunicator
 else:
     NcclCommunicator = Any
@@ -500,7 +500,15 @@ class DistributedArray:
         """Allgather operation
         """
         if deps.nccl_enabled and self.base_comm_nccl:
-            return nccl_allgather(self.base_comm_nccl, send_buf, recv_buf)
+            if hasattr(send_buf, "shape"):
+                send_shapes = self.base_comm.allgather(send_buf.shape)
+                (padded_send, padded_recv) = _prepare_nccl_allgather_inputs(send_buf, send_shapes)
+                # TODO: Should we ignore recv_buf completely in this case ?
+                raw_recv = nccl_allgather(self.base_comm_nccl, padded_send, recv_buf if recv_buf else padded_recv)
+                return _unroll_nccl_allgather_recv(raw_recv, padded_send.shape, send_shapes)
+            else:
+                # still works for a send_buf whose type is a tuple for _nccl_local_shapes
+                return nccl_allgather(self.base_comm_nccl, send_buf, recv_buf)
         else:
             if recv_buf is None:
                 return self.base_comm.allgather(send_buf)
@@ -511,7 +519,13 @@ class DistributedArray:
         """Allgather operation with subcommunicator
         """
         if deps.nccl_enabled and getattr(self, "base_comm_nccl"):
-            return nccl_allgather(self.sub_comm, send_buf, recv_buf)
+            if hasattr(send_buf, "shape"):
+                send_shapes = self.base_comm.allgather(send_buf.shape)
+                (padded_send, padded_recv) = _prepare_nccl_allgather_inputs(send_buf, send_shapes)
+                raw_recv = nccl_allgather(self.sub_comm, padded_send, recv_buf if recv_buf else padded_recv)
+                return _unroll_nccl_allgather_recv(raw_recv, padded_send.shape, send_shapes)
+            else:
+                return nccl_allgather(self.sub_comm, send_buf, recv_buf)
         else:
             if recv_buf is None:
                 return self.sub_comm.allgather(send_buf)

--- a/pylops_mpi/signalprocessing/Fredholm1.py
+++ b/pylops_mpi/signalprocessing/Fredholm1.py
@@ -111,7 +111,7 @@ class MPIFredholm1(MPILinearOperator):
         if x.partition not in [Partition.BROADCAST, Partition.UNSAFE_BROADCAST]:
             raise ValueError(f"x should have partition={Partition.BROADCAST},{Partition.UNSAFE_BROADCAST}"
                              f"Got  {x.partition} instead...")
-        y = DistributedArray(global_shape=self.shape[0], 
+        y = DistributedArray(global_shape=self.shape[0],
                              base_comm=x.base_comm,
                              base_comm_nccl=x.base_comm_nccl,
                              partition=x.partition,
@@ -128,11 +128,6 @@ class MPIFredholm1(MPILinearOperator):
             for isl in range(self.nsls[self.rank]):
                 y1[isl] = ncp.dot(self.G[isl], x[isl])
         # gather results
-        # TODO: _allgather is supposed to be private to DistributedArray
-        # but so far, we do not take base_comm_nccl as an argument to Op.
-        # For consistency, y._allgather has to be called here.
-        # Alternatively, we can also do if-else checking x.base_comm_nccl, but that means
-        # we have to call function from _nccl.py
         y[:] = ncp.vstack(y._allgather(y1)).ravel()
         return y
 
@@ -141,7 +136,7 @@ class MPIFredholm1(MPILinearOperator):
         if x.partition not in [Partition.BROADCAST, Partition.UNSAFE_BROADCAST]:
             raise ValueError(f"x should have partition={Partition.BROADCAST},{Partition.UNSAFE_BROADCAST}"
                              f"Got  {x.partition} instead...")
-        y = DistributedArray(global_shape=self.shape[1], 
+        y = DistributedArray(global_shape=self.shape[1],
                              base_comm=x.base_comm,
                              base_comm_nccl=x.base_comm_nccl,
                              partition=x.partition,
@@ -176,8 +171,8 @@ class MPIFredholm1(MPILinearOperator):
         if self.usematmul and isinstance(recv, ncp.ndarray) :
             # unrolling
             chunk_size = self.ny * self.nz
-            num_partition = (len(recv)+chunk_size-1)//chunk_size
-            recv = ncp.vstack([recv[i*chunk_size: (i+1)*chunk_size].reshape(self.nz, self.ny).T for i in range(num_partition)])
+            num_partition = (len(recv) + chunk_size - 1) // chunk_size
+            recv = ncp.vstack([recv[i * chunk_size: (i + 1) * chunk_size].reshape(self.nz, self.ny).T for i in range(num_partition)])
         else:
             recv = ncp.vstack(recv)
         y[:] = recv.ravel()

--- a/pylops_mpi/signalprocessing/Fredholm1.py
+++ b/pylops_mpi/signalprocessing/Fredholm1.py
@@ -130,12 +130,10 @@ class MPIFredholm1(MPILinearOperator):
         # gather results
         # TODO: _allgather is supposed to be private to DistributedArray
         # but so far, we do not take base_comm_nccl as an argument to Op.
-        # For consistency, y._allgather has to be call here.
-        # we can do if else for x.base_comm_nccl, but that means
+        # For consistency, y._allgather has to be called here.
+        # Alternatively, we can also do if-else checking x.base_comm_nccl, but that means
         # we have to call function from _nccl.py
-        # y[:] = np.vstack(y._allgather(y1)).ravel()
-        recv = y._allgather(y1)
-        y[:] = recv.ravel()
+        y[:] = ncp.vstack(y._allgather(y1)).ravel()
         return y
 
     def _rmatvec(self, x: NDArray) -> NDArray:
@@ -172,11 +170,15 @@ class MPIFredholm1(MPILinearOperator):
                     y1[isl] = ncp.dot(x[isl].T.conj(), self.G[isl]).T.conj()
 
         # gather results
-        recv = y._allgather(y1) 
-        if self.usematmul:
-            # unrolling like DistributedArray asarray()
+        recv = y._allgather(y1)
+        # TODO: current of _allgather will call non-buffered MPI-AllGather (sub-optimal for CuPy+MPI)
+        # which returns a list (not flatten) and does not require unrolling
+        if self.usematmul and isinstance(recv, ncp.ndarray) :
+            # unrolling
             chunk_size = self.ny * self.nz
-            recv = ncp.vstack([recv[i*chunk_size: (i+1)*chunk_size].reshape(self.nz, self.ny).T for i in range((len(recv)+chunk_size-1)//chunk_size)])
-
+            num_partition = (len(recv)+chunk_size-1)//chunk_size
+            recv = ncp.vstack([recv[i*chunk_size: (i+1)*chunk_size].reshape(self.nz, self.ny).T for i in range(num_partition)])
+        else:
+            recv = ncp.vstack(recv)
         y[:] = recv.ravel()
         return y

--- a/pylops_mpi/utils/_nccl.py
+++ b/pylops_mpi/utils/_nccl.py
@@ -6,7 +6,9 @@ __all__ = [
     "nccl_bcast",
     "nccl_asarray",
     "nccl_send",
-    "nccl_recv"
+    "nccl_recv",
+    "_prepare_nccl_allgather_inputs",
+    "_unroll_nccl_allgather_recv"
 ]
 
 from enum import IntEnum
@@ -251,6 +253,83 @@ def nccl_bcast(nccl_comm, local_array, index, value) -> None:
     )
 
 
+def _prepare_nccl_allgather_inputs(send_buf, send_buf_shapes) -> tuple[cp.ndarray, cp.ndarray]:
+    """ Preparing the send_buf and recv_buf for the NCCL allgather (nccl_allgather)
+
+    NCCL's allGather requires the sending buffer to have the same size for every device.
+    Therefore, the padding is required when the array is not evenly partitioned across
+    all the ranks. The padding is applied such that the sending buffer has the size of
+    each dimension corresponding to the max possible size of that dimension.
+
+    Receiver buff (recv_buf) will have the size n_rank * send_buf.size
+
+    Parameters
+    ----------
+    send_buf : :obj:`cupy.ndarray` or array-like
+        The data buffer from the local GPU to be sent for allgather.
+    send_buf_shapes: :obj:`list`
+        A list of shapes for each GPU send_buf (used to calculate padding size)
+
+    Returns
+    -------
+    tuple[send_buf, recv_buf]: :obj:`tuple`
+        A tuple of (send_buf, recv_buf) will an appropriate size, shape and dtype for NCCL allgather
+
+    """
+    sizes_each_dim = list(zip(*send_buf_shapes))
+    send_shape = tuple(map(max, sizes_each_dim))
+    pad_size = [
+        (0, s_shape - l_shape) for s_shape, l_shape in zip(send_shape, send_buf.shape)
+    ]
+
+    send_buf = cp.pad(
+        send_buf, pad_size, mode="constant", constant_values=0
+    )
+
+    # NCCL recommends to use one MPI Process per GPU and so size of receiving buffer can be inferred
+    ndev = len(send_buf_shapes)
+    recv_buf = cp.zeros(ndev * send_buf.size, dtype=send_buf.dtype)
+
+    return (send_buf, recv_buf)
+
+
+def _unroll_nccl_allgather_recv(recv_buf, padded_send_buf_shape, send_buf_shapes) -> list:
+    """ Remove the padded elements in recv_buff, extract an individual array from each device and return them as a list of arrays
+
+    Each GPU may send array with a different shape, so the return type has to be a list of array
+    instead of the concatenated array.
+
+    Parameters
+    ----------
+    recv_buf: :obj:`cupy.ndarray` or array-like
+        The data buffer returned from nccl_allgather call
+    padded_send_buf_shape: :obj:`tuple`:int
+        The size of send_buf after padding used in nccl_allgather
+    send_buf_shapes: :obj:`list`
+        A list of original shapes for each GPU send_buf prior to padding
+
+    Returns
+    -------
+    chunks: :obj:`list`
+        A list of `cupy.ndarray` from each GPU with the padded element removed
+    """
+
+    ndev = len(send_buf_shapes)
+    # extract an individual array from each device
+    chunk_size = np.prod(padded_send_buf_shape)
+    chunks = [
+        recv_buf[i * chunk_size:(i + 1) * chunk_size] for i in range(ndev)
+    ]
+
+    # Remove padding from each array: the padded value may appear somewhere
+    # in the middle of the flat array and thus the reshape and slicing for each dimension is required
+    for i in range(ndev):
+        slicing = tuple(slice(0, end) for end in send_buf_shapes[i])
+        chunks[i] = chunks[i].reshape(padded_send_buf_shape)[slicing]
+
+    return chunks
+
+
 def nccl_asarray(nccl_comm, local_array, local_shapes, axis) -> cp.ndarray:
     """Global view of the array
 
@@ -271,41 +350,12 @@ def nccl_asarray(nccl_comm, local_array, local_shapes, axis) -> cp.ndarray:
     -------
     final_array : :obj:`cupy.ndarray`
         Global array gathered from all GPUs and concatenated along `axis`.
-
-    Notes
-    -----
-    NCCL's allGather requires the sending buffer to have the same size for every device.
-    Therefore, the padding is required when the array is not evenly partitioned across
-    all the ranks. The padding is applied such that the sending buffer has the size of
-    each dimension corresponding to the max possible size of that dimension.
     """
-    sizes_each_dim = list(zip(*local_shapes))
 
-    send_shape = tuple(map(max, sizes_each_dim))
-    pad_size = [
-        (0, s_shape - l_shape) for s_shape, l_shape in zip(send_shape, local_array.shape)
-    ]
-
-    send_buf = cp.pad(
-        local_array, pad_size, mode="constant", constant_values=0
-    )
-
-    # NCCL recommends to use one MPI Process per GPU and so size of receiving buffer can be inferred
-    ndev = len(local_shapes)
-    recv_buf = cp.zeros(ndev * send_buf.size, dtype=send_buf.dtype)
+    (send_buf, recv_buf) = _prepare_nccl_allgather_inputs(local_array, local_shapes)
     nccl_allgather(nccl_comm, send_buf, recv_buf)
+    chunks = _unroll_nccl_allgather_recv(recv_buf, send_buf.shape, local_shapes)
 
-    # extract an individual array from each device
-    chunk_size = np.prod(send_shape)
-    chunks = [
-        recv_buf[i * chunk_size:(i + 1) * chunk_size] for i in range(ndev)
-    ]
-
-    # Remove padding from each array: the padded value may appear somewhere
-    # in the middle of the flat array and thus the reshape and slicing for each dimension is required
-    for i in range(ndev):
-        slicing = tuple(slice(0, end) for end in local_shapes[i])
-        chunks[i] = chunks[i].reshape(send_shape)[slicing]
     # combine back to single global array
     return cp.concatenate(chunks, axis=axis)
 

--- a/pylops_mpi/utils/_nccl.py
+++ b/pylops_mpi/utils/_nccl.py
@@ -1,4 +1,6 @@
 __all__ = [
+    "_prepare_nccl_allgather_inputs",
+    "_unroll_nccl_allgather_recv",
     "initialize_nccl_comm",
     "nccl_split",
     "nccl_allgather",
@@ -7,16 +9,16 @@ __all__ = [
     "nccl_asarray",
     "nccl_send",
     "nccl_recv",
-    "_prepare_nccl_allgather_inputs",
-    "_unroll_nccl_allgather_recv"
 ]
 
 from enum import IntEnum
+from typing import Tuple
 from mpi4py import MPI
 import os
 import numpy as np
 import cupy as cp
 import cupy.cuda.nccl as nccl
+
 
 cupy_to_nccl_dtype = {
     "float32": nccl.NCCL_FLOAT32,
@@ -59,6 +61,85 @@ def _nccl_buf_size(buf, count=None):
         return 2 * count if count else 2 * buf.size
     else:
         return count if count else buf.size
+
+
+def _prepare_nccl_allgather_inputs(send_buf, send_buf_shapes) -> Tuple[cp.ndarray, cp.ndarray]:
+    r""" Prepare send_buf and recv_buf for NCCL allgather (nccl_allgather)
+
+    NCCL's allGather requires the sending buffer to have the same size for every device.
+    Therefore, padding is required when the array is not evenly partitioned across
+    all the ranks. The padding is applied such that the each dimension of the sending buffers
+    is equal to the max size of that dimension across all ranks.
+
+    Similarly, each receiver buffer (recv_buf) is created with size equal to :math:n_rank \cdot send_buf.size
+
+    Parameters
+    ----------
+    send_buf : :obj:`cupy.ndarray` or array-like
+        The data buffer from the local GPU to be sent for allgather.
+    send_buf_shapes: :obj:`list`
+        A list of shapes for each GPU send_buf (used to calculate padding size)
+
+    Returns
+    -------
+    send_buf: :obj:`cupy.ndarray`
+        A buffer containing the data and padded elements to be sent by this rank.
+    recv_buf : :obj:`cupy.ndarray`
+        An empty, padded buffer to gather data from all GPUs.
+    """
+    sizes_each_dim = list(zip(*send_buf_shapes))
+    send_shape = tuple(map(max, sizes_each_dim))
+    pad_size = [
+        (0, s_shape - l_shape) for s_shape, l_shape in zip(send_shape, send_buf.shape)
+    ]
+
+    send_buf = cp.pad(
+        send_buf, pad_size, mode="constant", constant_values=0
+    )
+
+    # NCCL recommends to use one MPI Process per GPU and so size of receiving buffer can be inferred
+    ndev = len(send_buf_shapes)
+    recv_buf = cp.zeros(ndev * send_buf.size, dtype=send_buf.dtype)
+
+    return send_buf, recv_buf
+
+
+def _unroll_nccl_allgather_recv(recv_buf, padded_send_buf_shape, send_buf_shapes) -> list:
+    """Unrolll recv_buf after NCCL allgather (nccl_allgather)
+
+    Remove the padded elements in recv_buff, extract an individual array from each device and return them as a list of arrays
+    Each GPU may send array with a different shape, so the return type has to be a list of array
+    instead of the concatenated array.
+
+    Parameters
+    ----------
+    recv_buf: :obj:`cupy.ndarray` or array-like
+        The data buffer returned from nccl_allgather call
+    padded_send_buf_shape: :obj:`tuple`:int
+        The size of send_buf after padding used in nccl_allgather
+    send_buf_shapes: :obj:`list`
+        A list of original shapes for each GPU send_buf prior to padding
+
+    Returns
+    -------
+    chunks: :obj:`list`
+        A list of `cupy.ndarray` from each GPU with the padded element removed
+    """
+
+    ndev = len(send_buf_shapes)
+    # extract an individual array from each device
+    chunk_size = np.prod(padded_send_buf_shape)
+    chunks = [
+        recv_buf[i * chunk_size:(i + 1) * chunk_size] for i in range(ndev)
+    ]
+
+    # Remove padding from each array: the padded value may appear somewhere
+    # in the middle of the flat array and thus the reshape and slicing for each dimension is required
+    for i in range(ndev):
+        slicing = tuple(slice(0, end) for end in send_buf_shapes[i])
+        chunks[i] = chunks[i].reshape(padded_send_buf_shape)[slicing]
+
+    return chunks
 
 
 def mpi_op_to_nccl(mpi_op) -> NcclOp:
@@ -253,83 +334,6 @@ def nccl_bcast(nccl_comm, local_array, index, value) -> None:
     )
 
 
-def _prepare_nccl_allgather_inputs(send_buf, send_buf_shapes) -> tuple[cp.ndarray, cp.ndarray]:
-    """ Preparing the send_buf and recv_buf for the NCCL allgather (nccl_allgather)
-
-    NCCL's allGather requires the sending buffer to have the same size for every device.
-    Therefore, the padding is required when the array is not evenly partitioned across
-    all the ranks. The padding is applied such that the sending buffer has the size of
-    each dimension corresponding to the max possible size of that dimension.
-
-    Receiver buff (recv_buf) will have the size n_rank * send_buf.size
-
-    Parameters
-    ----------
-    send_buf : :obj:`cupy.ndarray` or array-like
-        The data buffer from the local GPU to be sent for allgather.
-    send_buf_shapes: :obj:`list`
-        A list of shapes for each GPU send_buf (used to calculate padding size)
-
-    Returns
-    -------
-    tuple[send_buf, recv_buf]: :obj:`tuple`
-        A tuple of (send_buf, recv_buf) will an appropriate size, shape and dtype for NCCL allgather
-
-    """
-    sizes_each_dim = list(zip(*send_buf_shapes))
-    send_shape = tuple(map(max, sizes_each_dim))
-    pad_size = [
-        (0, s_shape - l_shape) for s_shape, l_shape in zip(send_shape, send_buf.shape)
-    ]
-
-    send_buf = cp.pad(
-        send_buf, pad_size, mode="constant", constant_values=0
-    )
-
-    # NCCL recommends to use one MPI Process per GPU and so size of receiving buffer can be inferred
-    ndev = len(send_buf_shapes)
-    recv_buf = cp.zeros(ndev * send_buf.size, dtype=send_buf.dtype)
-
-    return (send_buf, recv_buf)
-
-
-def _unroll_nccl_allgather_recv(recv_buf, padded_send_buf_shape, send_buf_shapes) -> list:
-    """ Remove the padded elements in recv_buff, extract an individual array from each device and return them as a list of arrays
-
-    Each GPU may send array with a different shape, so the return type has to be a list of array
-    instead of the concatenated array.
-
-    Parameters
-    ----------
-    recv_buf: :obj:`cupy.ndarray` or array-like
-        The data buffer returned from nccl_allgather call
-    padded_send_buf_shape: :obj:`tuple`:int
-        The size of send_buf after padding used in nccl_allgather
-    send_buf_shapes: :obj:`list`
-        A list of original shapes for each GPU send_buf prior to padding
-
-    Returns
-    -------
-    chunks: :obj:`list`
-        A list of `cupy.ndarray` from each GPU with the padded element removed
-    """
-
-    ndev = len(send_buf_shapes)
-    # extract an individual array from each device
-    chunk_size = np.prod(padded_send_buf_shape)
-    chunks = [
-        recv_buf[i * chunk_size:(i + 1) * chunk_size] for i in range(ndev)
-    ]
-
-    # Remove padding from each array: the padded value may appear somewhere
-    # in the middle of the flat array and thus the reshape and slicing for each dimension is required
-    for i in range(ndev):
-        slicing = tuple(slice(0, end) for end in send_buf_shapes[i])
-        chunks[i] = chunks[i].reshape(padded_send_buf_shape)[slicing]
-
-    return chunks
-
-
 def nccl_asarray(nccl_comm, local_array, local_shapes, axis) -> cp.ndarray:
     """Global view of the array
 
@@ -352,7 +356,7 @@ def nccl_asarray(nccl_comm, local_array, local_shapes, axis) -> cp.ndarray:
         Global array gathered from all GPUs and concatenated along `axis`.
     """
 
-    (send_buf, recv_buf) = _prepare_nccl_allgather_inputs(local_array, local_shapes)
+    send_buf, recv_buf = _prepare_nccl_allgather_inputs(local_array, local_shapes)
     nccl_allgather(nccl_comm, send_buf, recv_buf)
     chunks = _unroll_nccl_allgather_recv(recv_buf, send_buf.shape, local_shapes)
 

--- a/pylops_mpi/utils/_nccl.py
+++ b/pylops_mpi/utils/_nccl.py
@@ -39,6 +39,20 @@ class NcclOp(IntEnum):
 
 
 def _nccl_buf_size(buf, count=None):
+    """ Get an appropriate buffer size according to the dtype of buf
+
+    Parameters
+    ----------
+    buf : :obj:`cupy.ndarray` or array-like
+        The data buffer from the local GPU to be sent.
+
+    count : :obj:`int`, optional
+        Number of elements to send from `buf`, if not sending the every element in `buf`.
+    Returns:
+    -------
+    :obj:`int`
+        An appropriate number of elements to send from `send_buf` for NCCL communication.
+    """
     if buf.dtype in ['complex64', 'complex128']:
         return 2 * count if count else 2 * buf.size
     else:

--- a/tests_nccl/test_blockdiag_nccl.py
+++ b/tests_nccl/test_blockdiag_nccl.py
@@ -18,15 +18,15 @@ from pylops_mpi.utils._nccl import initialize_nccl_comm
 nccl_comm = initialize_nccl_comm()
 
 par1 = {'ny': 101, 'nx': 101, 'dtype': np.float64}
-# par1j = {'ny': 101, 'nx': 101, 'dtype': np.complex128}
+par1j = {'ny': 101, 'nx': 101, 'dtype': np.complex128}
 par2 = {'ny': 301, 'nx': 101, 'dtype': np.float64}
-# par2j = {'ny': 301, 'nx': 101, 'dtype': np.complex128}
+par2j = {'ny': 301, 'nx': 101, 'dtype': np.complex128}
 
 np.random.seed(42)
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
 def test_blockdiag_nccl(par):
     """Test the MPIBlockDiag with NCCL"""
     size = MPI.COMM_WORLD.Get_size()
@@ -71,7 +71,7 @@ def test_blockdiag_nccl(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
 def test_stacked_blockdiag_nccl(par):
     """Tests for MPIStackedBlogDiag with NCCL"""
     size = MPI.COMM_WORLD.Get_size()

--- a/tests_nccl/test_derivative_nccl.py
+++ b/tests_nccl/test_derivative_nccl.py
@@ -38,13 +38,13 @@ par1b = {
     "partition": pylops_mpi.Partition.BROADCAST,
 }
 
-# par1j = {
-#     "nz": 600,
-#     "dz": 1.0,
-#     "edge": False,
-#     "dtype": np.complex128,
-#     "partition": pylops_mpi.Partition.SCATTER
-# }
+par1j = {
+    "nz": 600,
+    "dz": 1.0,
+    "edge": False,
+    "dtype": np.complex128,
+    "partition": pylops_mpi.Partition.SCATTER
+}
 
 par1e = {
     "nz": 600,
@@ -70,13 +70,13 @@ par2b = {
     "partition": pylops_mpi.Partition.BROADCAST,
 }
 
-# par2j = {
-#     "nz": (100, 151),
-#     "dz": 1.0,
-#     "edge": False,
-#     "dtype": np.complex128,
-#     "partition": pylops_mpi.Partition.SCATTER
-# }
+par2j = {
+    "nz": (100, 151),
+    "dz": 1.0,
+    "edge": False,
+    "dtype": np.complex128,
+    "partition": pylops_mpi.Partition.SCATTER
+}
 
 par2e = {
     "nz": (100, 151),
@@ -102,13 +102,13 @@ par3b = {
     "partition": pylops_mpi.Partition.BROADCAST,
 }
 
-# par3j = {
-#     "nz": (101, 51, 100),
-#     "dz": 0.4,
-#     "edge": True,
-#     "dtype": np.complex128,
-#     "partition": pylops_mpi.Partition.SCATTER
-# }
+par3j = {
+    "nz": (101, 51, 100),
+    "dz": 0.4,
+    "edge": True,
+    "dtype": np.complex128,
+    "partition": pylops_mpi.Partition.SCATTER
+}
 
 par3e = {
     "nz": (101, 51, 100),
@@ -134,13 +134,13 @@ par4b = {
     "partition": pylops_mpi.Partition.BROADCAST,
 }
 
-# par4j = {
-#     "nz": (79, 101, 50),
-#     "dz": 0.4,
-#     "edge": True,
-#     "dtype": np.complex128,
-#     "partition": pylops_mpi.Partition.SCATTER
-# }
+par4j = {
+    "nz": (79, 101, 50),
+    "dz": 0.4,
+    "edge": True,
+    "dtype": np.complex128,
+    "partition": pylops_mpi.Partition.SCATTER
+}
 
 par4e = {
     "nz": (79, 101, 50),
@@ -188,24 +188,10 @@ par6e = {
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize(
-    "par",
-    [
-        (par1),
-        (par1b),
-        (par1e),
-        (par2),
-        (par2b),
-        (par2e),
-        (par3),
-        (par3b),
-        (par3e),
-        (par4),
-        (par4b),
-        (par4e),
-    ],
-)
-def test_first_derivative_forward(par):
+@pytest.mark.parametrize("par", [(par1), (par1b), (par1j), (par1e), (par2), (par2b),
+                                 (par2j), (par2e), (par3), (par3b), (par3j), (par3e),
+                                 (par4), (par4b), (par4j), (par4e)])
+def test_first_derivative_forward_nccl(par):
     """MPIFirstDerivative operator (forward stencil)"""
     Fop_MPI = pylops_mpi.MPIFirstDerivative(
         dims=par["nz"],
@@ -250,24 +236,10 @@ def test_first_derivative_forward(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize(
-    "par",
-    [
-        (par1),
-        (par1b),
-        (par1e),
-        (par2),
-        (par2b),
-        (par2e),
-        (par3),
-        (par3b),
-        (par3e),
-        (par4),
-        (par4b),
-        (par4e),
-    ],
-)
-def test_first_derivative_backward(par):
+@pytest.mark.parametrize("par", [(par1), (par1b), (par1j), (par1e), (par2), (par2b),
+                                 (par2j), (par2e), (par3), (par3b), (par3j), (par3e),
+                                 (par4), (par4b), (par4j), (par4e)])
+def test_first_derivative_backward_nccl(par):
     """MPIFirstDerivative operator (backward stencil)"""
     Fop_MPI = pylops_mpi.MPIFirstDerivative(
         dims=par["nz"],
@@ -311,24 +283,10 @@ def test_first_derivative_backward(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize(
-    "par",
-    [
-        (par1),
-        (par1b),
-        (par1e),
-        (par2),
-        (par2b),
-        (par2e),
-        (par3),
-        (par3b),
-        (par3e),
-        (par4),
-        (par4b),
-        (par4e),
-    ],
-)
-def test_first_derivative_centered(par):
+@pytest.mark.parametrize("par", [(par1), (par1b), (par1j), (par1e), (par2), (par2b),
+                                 (par2j), (par2e), (par3), (par3b), (par3j), (par3e),
+                                 (par4), (par4b), (par4j), (par4e)])
+def test_first_derivative_centered_nccl(par):
     """MPIFirstDerivative operator (centered stencil)"""
     for order in [3, 5]:
         Fop_MPI = pylops_mpi.MPIFirstDerivative(
@@ -375,24 +333,10 @@ def test_first_derivative_centered(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize(
-    "par",
-    [
-        (par1),
-        (par1b),
-        (par1e),
-        (par2),
-        (par2b),
-        (par2e),
-        (par3),
-        (par3b),
-        (par3e),
-        (par4),
-        (par4b),
-        (par4e),
-    ],
-)
-def test_second_derivative_forward(par):
+@pytest.mark.parametrize("par", [(par1), (par1b), (par1j), (par1e), (par2), (par2b),
+                                 (par2j), (par2e), (par3), (par3b), (par3j), (par3e),
+                                 (par4), (par4b), (par4j), (par4e)])
+def test_second_derivative_forward_nccl(par):
     """MPISecondDerivative operator (forward stencil)"""
     Sop_MPI = pylops_mpi.basicoperators.MPISecondDerivative(
         dims=par["nz"],
@@ -436,24 +380,10 @@ def test_second_derivative_forward(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize(
-    "par",
-    [
-        (par1),
-        (par1b),
-        (par1e),
-        (par2),
-        (par2b),
-        (par2e),
-        (par3),
-        (par3b),
-        (par3e),
-        (par4),
-        (par4b),
-        (par4e),
-    ],
-)
-def test_second_derivative_backward(par):
+@pytest.mark.parametrize("par", [(par1), (par1b), (par1j), (par1e), (par2), (par2b),
+                                 (par2j), (par2e), (par3), (par3b), (par3j), (par3e),
+                                 (par4), (par4b), (par4j), (par4e)])
+def test_second_derivative_backward_nccl(par):
     """MPISecondDerivative operator (backward stencil)"""
     Sop_MPI = pylops_mpi.basicoperators.MPISecondDerivative(
         dims=par["nz"],
@@ -497,24 +427,10 @@ def test_second_derivative_backward(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize(
-    "par",
-    [
-        (par1),
-        (par1b),
-        (par1e),
-        (par2),
-        (par2b),
-        (par2e),
-        (par3),
-        (par3b),
-        (par3e),
-        (par4),
-        (par4b),
-        (par4e),
-    ],
-)
-def test_second_derivative_centered(par):
+@pytest.mark.parametrize("par", [(par1), (par1b), (par1j), (par1e), (par2), (par2b),
+                                 (par2j), (par2e), (par3), (par3b), (par3j), (par3e),
+                                 (par4), (par4b), (par4j), (par4e)])
+def test_second_derivative_centered_nccl(par):
     """MPISecondDerivative operator (centered stencil)"""
     Sop_MPI = pylops_mpi.basicoperators.MPISecondDerivative(
         dims=par["nz"],
@@ -559,7 +475,7 @@ def test_second_derivative_centered(par):
 
 @pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize("par", [(par5), (par5e), (par6), (par6e)])
-def test_laplacian(par):
+def test_laplacian_nccl(par):
     """MPILaplacian Operator"""
     for kind in ["forward", "backward", "centered"]:
         Lop_MPI = pylops_mpi.basicoperators.MPILaplacian(
@@ -607,7 +523,7 @@ def test_laplacian(par):
 
 @pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize("par", [(par5), (par5e), (par6), (par6e)])
-def test_gradient(par):
+def test_gradient_nccl(par):
     """MPIGradient Operator"""
     for kind in ["forward", "backward", "centered"]:
         Gop_MPI = pylops_mpi.basicoperators.MPIGradient(

--- a/tests_nccl/test_distributedarray_nccl.py
+++ b/tests_nccl/test_distributedarray_nccl.py
@@ -19,90 +19,67 @@ np.random.seed(42)
 
 nccl_comm = initialize_nccl_comm()
 
-par1 = {
-    "global_shape": (500, 501),
-    "partition": Partition.SCATTER,
-    "dtype": np.float64,
-    "axis": 1,
-}
+par1 = {'global_shape': (500, 501),
+        'partition': Partition.SCATTER, 'dtype': np.float64,
+        'axis': 1}
+par1j = {'global_shape': (501, 500),
+         'partition': Partition.SCATTER, 'dtype': np.complex128,
+         'axis': 0}
+par2 = {'global_shape': (500, 501),
+        'partition': Partition.BROADCAST, 'dtype': np.float64,
+        'axis': 1}
+par2j = {'global_shape': (501, 500),
+         'partition': Partition.BROADCAST, 'dtype': np.complex128,
+         'axis': 0}
 
-par2 = {
-    "global_shape": (500, 501),
-    "partition": Partition.BROADCAST,
-    "dtype": np.float64,
-    "axis": 1,
-}
+par3 = {'global_shape': (200, 201, 101),
+        'partition': Partition.SCATTER,
+        'dtype': np.float64, 'axis': 1}
 
-par3 = {
-    "global_shape": (200, 201, 101),
-    "partition": Partition.SCATTER,
-    "dtype": np.float64,
-    "axis": 1,
-}
+par3j = {'global_shape': (200, 201, 101),
+         'partition': Partition.SCATTER,
+         'dtype': np.complex128, 'axis': 2}
 
-par4 = {
-    "x": np.random.normal(100, 100, (500, 501)),
-    "partition": Partition.SCATTER,
-    "axis": 1,
-}
+par4 = {'x': np.random.normal(100, 100, (500, 501)),
+        'partition': Partition.SCATTER, 'axis': 1}
 
-par5 = {
-    "x": np.random.normal(300, 300, (500, 501)),
-    "partition": Partition.SCATTER,
-    "axis": 1,
-}
+par4j = {'x': np.random.normal(100, 100, (500, 501)) + 1.0j * np.random.normal(50, 50, (500, 501)),
+         'partition': Partition.SCATTER, 'axis': 1}
 
-par6 = {
-    "x": np.random.normal(100, 100, (600, 600)),
-    "partition": Partition.SCATTER,
-    "axis": 0,
-}
+par5 = {'x': np.random.normal(300, 300, (500, 501)),
+        'partition': Partition.SCATTER, 'axis': 1}
 
-par6b = {
-    "x": np.random.normal(100, 100, (600, 600)),
-    "partition": Partition.BROADCAST,
-    "axis": 0,
-}
+par5j = {'x': np.random.normal(300, 300, (500, 501)) + 1.0j * np.random.normal(50, 50, (500, 501)),
+         'partition': Partition.SCATTER, 'axis': 1}
 
-par7 = {
-    "x": np.random.normal(300, 300, (600, 600)),
-    "partition": Partition.SCATTER,
-    "axis": 0,
-}
+par6 = {'x': np.random.normal(100, 100, (600, 600)),
+        'partition': Partition.SCATTER, 'axis': 0}
 
-par7b = {
-    "x": np.random.normal(300, 300, (600, 600)),
-    "partition": Partition.BROADCAST,
-    "axis": 0,
-}
+par6b = {'x': np.random.normal(100, 100, (600, 600)),
+         'partition': Partition.BROADCAST, 'axis': 0}
 
-par8 = {
-    "x": np.random.normal(100, 100, (1200,)),
-    "partition": Partition.SCATTER,
-    "axis": 0,
-}
+par7 = {'x': np.random.normal(300, 300, (600, 600)),
+        'partition': Partition.SCATTER, 'axis': 0}
 
-par8b = {
-    "x": np.random.normal(100, 100, (1200,)),
-    "partition": Partition.BROADCAST,
-    "axis": 0,
-}
+par7b = {'x': np.random.normal(300, 300, (600, 600)),
+         'partition': Partition.BROADCAST, 'axis': 0}
 
-par9 = {
-    "x": np.random.normal(300, 300, (1200,)),
-    "partition": Partition.SCATTER,
-    "axis": 0,
-}
+par8 = {'x': np.random.normal(100, 100, (1200,)),
+        'partition': Partition.SCATTER, 'axis': 0}
 
-par9b = {
-    "x": np.random.normal(300, 300, (1200,)),
-    "partition": Partition.BROADCAST,
-    "axis": 0,
-}
+par8b = {'x': np.random.normal(100, 100, (1200,)),
+         'partition': Partition.BROADCAST, 'axis': 0}
+
+par9 = {'x': np.random.normal(300, 300, (1200,)),
+        'partition': Partition.SCATTER, 'axis': 0}
+
+par9b = {'x': np.random.normal(300, 300, (1200,)),
+         'partition': Partition.BROADCAST, 'axis': 0}
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2), (par3)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2),
+                                 (par2j), (par3), (par3j)])
 def test_creation_nccl(par):
     """Test creation of local arrays"""
     distributed_array = DistributedArray(
@@ -169,7 +146,7 @@ def test_creation_nccl(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par4), (par5)])
+@pytest.mark.parametrize("par", [(par4), (par4j), (par5), (par5j)])
 def test_to_dist_nccl(par):
     """Test the ``to_dist`` method"""
     x_gpu = cp.asarray(par["x"])
@@ -185,7 +162,8 @@ def test_to_dist_nccl(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2), (par3)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2),
+                                 (par2j), (par3), (par3j)])
 def test_local_shapes_nccl(par):
     """Test the `local_shapes` parameter in DistributedArray"""
     # Reverse the local_shapes to test the local_shapes parameter
@@ -219,7 +197,7 @@ def test_local_shapes_nccl(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par1, par2", [(par4, par5)])
+@pytest.mark.parametrize("par1, par2", [(par4, par5), (par4j, par5j)])
 def test_distributed_math_nccl(par1, par2):
     """Test the Element-Wise Addition, Subtraction and Multiplication"""
     x1_gpu = cp.asarray(par1["x"])
@@ -254,9 +232,8 @@ def test_distributed_math_nccl(par1, par2):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize(
-    "par1, par2", [(par6, par7), (par6b, par7b), (par8, par9), (par8b, par9b)]
-)
+@pytest.mark.parametrize("par1, par2", [(par6, par7), (par6b, par7b),
+                                        (par8, par9), (par8b, par9b)])
 def test_distributed_dot_nccl(par1, par2):
     """Test Distributed Dot product"""
     x1_gpu = cp.asarray(par1["x"])
@@ -275,21 +252,9 @@ def test_distributed_dot_nccl(par1, par2):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize(
-    "par",
-    [
-        (par4),
-        (par5),
-        (par6),
-        (par6b),
-        (par7),
-        (par7b),
-        (par8),
-        (par8b),
-        (par9),
-        (par9b),
-    ],
-)
+@pytest.mark.parametrize("par", [(par4), (par4j), (par5), (par5j),
+                                 (par6), (par6b), (par7), (par7b),
+                                 (par8), (par8b), (par9), (par9b)])
 def test_distributed_norm_nccl(par):
     """Test Distributed numpy.linalg.norm method"""
     x_gpu = cp.asarray(par["x"])
@@ -344,9 +309,8 @@ def test_distributed_masked_nccl(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize(
-    "par1, par2", [(par6, par7), (par6b, par7b), (par8, par9), (par8b, par9b)]
-)
+@pytest.mark.parametrize("par1, par2", [(par6, par7), (par6b, par7b),
+                                        (par8, par9), (par8b, par9b)])
 def test_distributed_maskeddot_nccl(par1, par2):
     """Test Distributed Dot product with masked array"""
     # number of subcommunicators
@@ -398,9 +362,8 @@ def test_distributed_maskeddot_nccl(par1, par2):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize(
-    "par", [(par6), (par6b), (par7), (par7b), (par8), (par8b), (par9), (par9b)]
-)
+@pytest.mark.parametrize("par", [(par6), (par6b), (par7), (par7b),
+                                 (par8), (par8b), (par9), (par9b)])
 def test_distributed_maskednorm_nccl(par):
     """Test Distributed numpy.linalg.norm method with masked array"""
     # number of subcommunicators

--- a/tests_nccl/test_fredholm_nccl.py
+++ b/tests_nccl/test_fredholm_nccl.py
@@ -1,0 +1,161 @@
+"""Test the MPIFredholm1 class
+Designed to run with n GPUs (with 1 MPI process per GPU)
+$ mpiexec -n 3 pytest test_fredholm_nccl.py --with-mpi
+
+This file employs the same test sets as test_fredholm under NCCL environment
+"""
+import numpy as np
+import cupy as cp
+from numpy.testing import assert_allclose
+from mpi4py import MPI
+import pytest
+
+import pylops
+import pylops_mpi
+
+from pylops_mpi import DistributedArray
+from pylops_mpi.DistributedArray import local_split, Partition
+from pylops_mpi.signalprocessing import MPIFredholm1
+from pylops_mpi.utils.dottest import dottest
+from pylops_mpi.utils._nccl import initialize_nccl_comm
+
+np.random.seed(42)
+rank = MPI.COMM_WORLD.Get_rank()
+size = MPI.COMM_WORLD.Get_size()
+
+nccl_comm = initialize_nccl_comm()
+
+par1 = {
+    "nsl": 12,
+    "ny": 6,
+    "nx": 4,
+    "nz": 5,
+    "usematmul": False,
+    "saveGt": True,
+    "imag": 0,
+    "dtype": "float32",
+}  # real, saved Gt
+par2 = {
+    "nsl": 12,
+    "ny": 6,
+    "nx": 4,
+    "nz": 5,
+    "usematmul": True,
+    "saveGt": False,
+    "imag": 0,
+    "dtype": "float32",
+}  # real, unsaved Gt
+par3 = {
+    "nsl": 12,
+    "ny": 6,
+    "nx": 4,
+    "nz": 5,
+    "usematmul": False,
+    "saveGt": True,
+    "imag": 1j,
+    "dtype": "complex64",
+}  # complex, saved Gt
+par4 = {
+    "nsl": 12,
+    "ny": 6,
+    "nx": 4,
+    "nz": 5,
+    "saveGt": False,
+    "usematmul": False,
+    "imag": 1j,
+    "dtype": "complex64",
+}  # complex, unsaved Gt
+par5 = {
+    "nsl": 12,
+    "ny": 6,
+    "nx": 4,
+    "nz": 1,
+    "usematmul": True,
+    "saveGt": True,
+    "imag": 0,
+    "dtype": "float32",
+}  # real, saved Gt, nz=1
+par6 = {
+    "nsl": 12,
+    "ny": 6,
+    "nx": 4,
+    "nz": 1,
+    "usematmul": True,
+    "saveGt": False,
+    "imag": 0,
+    "dtype": "float32",
+}  # real, unsaved Gt, nz=1
+
+
+"""Seems to stop next tests from running
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1)])
+def test_Gsize1(par):
+    #Check error is raised if G has size 1 in any of the ranks
+    with pytest.raises(NotImplementedError):
+        _ = MPIFredholm1(
+                np.ones((1,  par["nx"], par["ny"])),
+                nz=par["nz"],
+                saveGt=par["saveGt"],
+                usematmul=par["usematmul"],
+                dtype=par["dtype"],
+            )
+"""
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
+def test_Fredholm1_nccl(par):
+    """Fredholm1 operator"""
+    np.random.seed(42)
+
+    _F = cp.arange(par["nsl"] * par["nx"] * par["ny"]).reshape(
+        par["nsl"], par["nx"], par["ny"]
+    ).astype(par["dtype"])
+    F = _F - par["imag"] * _F
+
+    # split across ranks
+    nsl_rank = local_split((par["nsl"], ), MPI.COMM_WORLD, Partition.SCATTER, 0)
+    nsl_ranks = np.concatenate(MPI.COMM_WORLD.allgather(nsl_rank))
+    islin_rank = np.insert(np.cumsum(nsl_ranks)[:-1] , 0, 0)[rank]
+    islend_rank = np.cumsum(nsl_ranks)[rank]
+    Frank = F[islin_rank:islend_rank]
+
+    Fop_MPI = MPIFredholm1(
+        Frank,
+        nz=par["nz"],
+        saveGt=par["saveGt"],
+        usematmul=par["usematmul"],
+        dtype=par["dtype"],
+    )
+
+    x = DistributedArray(global_shape=par["nsl"] * par["ny"] * par["nz"],
+                         base_comm_nccl=nccl_comm,
+                         partition=pylops_mpi.Partition.BROADCAST,
+                         dtype=par["dtype"],
+                         engine="cupy")
+    x[:] = 1. + par["imag"] * 1.
+    x_global = x.asarray()
+    # Forward
+    y_dist = Fop_MPI @ x
+    y = y_dist.asarray()
+    # Adjoint
+    y_adj_dist = Fop_MPI.H @ y_dist
+    y_adj = y_adj_dist.asarray()
+    # Dot test
+    dottest(Fop_MPI, x, y_dist, par["nsl"] * par["nx"] * par["nz"], par["nsl"] * par["ny"] * par["nz"])
+
+    if rank == 0:
+        Fop = pylops.signalprocessing.Fredholm1(
+            F.get(),
+            nz=par["nz"],
+            saveGt=par["saveGt"],
+            usematmul=par["usematmul"],
+            dtype=par["dtype"],
+        )
+
+        assert Fop_MPI.shape == Fop.shape
+        y_np = Fop @ x_global.get()
+        y_adj_np = Fop.H @ y_np
+        assert_allclose(y.get(), y_np, rtol=1e-14)
+        assert_allclose(y_adj.get(), y_adj_np, rtol=1e-14)

--- a/tests_nccl/test_linearop_nccl.py
+++ b/tests_nccl/test_linearop_nccl.py
@@ -29,13 +29,13 @@ rank = MPI.COMM_WORLD.Get_rank()
 size = MPI.COMM_WORLD.Get_size()
 
 par1 = {'ny': 101, 'nx': 101, 'dtype': np.float64}
-# par1j = {'ny': 101, 'nx': 101, 'dtype': np.complex128}
+par1j = {'ny': 101, 'nx': 101, 'dtype': np.complex128}
 par2 = {'ny': 301, 'nx': 101, 'dtype': np.float64}
-# par2j = {'ny': 301, 'nx': 101, 'dtype': np.complex128}
+par2j = {'ny': 301, 'nx': 101, 'dtype': np.complex128}
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
 def test_linearop_nccl(par):
     """Apply various overloaded operators (.H, .T, +, *, conj()) and ensure that the
     returned operator is still of `pylops_mpi.MPILinearOperator` type
@@ -51,7 +51,7 @@ def test_linearop_nccl(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1)])
+@pytest.mark.parametrize("par", [(par1), (par1j)])
 def test_square_linearop_nccl(par):
     """Apply overloaded operators (**, *) to square operators and
     ensure that the returned operator is still of `pylops_mpi.MPILinearOperator` type
@@ -63,7 +63,7 @@ def test_square_linearop_nccl(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
 def test_transpose_nccl(par):
     """Test the TransposeLinearOperator"""
     Op = pylops.MatrixMult(A=((rank + 1) * cp.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
@@ -98,7 +98,7 @@ def test_transpose_nccl(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
 def test_scaled_nccl(par):
     """Test the ScaledLinearOperator"""
     Op = pylops.MatrixMult(A=((rank + 1) * cp.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
@@ -132,8 +132,8 @@ def test_scaled_nccl(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1)])
-def test_power(par):
+@pytest.mark.parametrize("par", [(par1), (par1j)])
+def test_power_nccl(par):
     """Test the PowerLinearOperator"""
     Op = pylops.MatrixMult(A=((rank + 1) * cp.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
     BDiag_MPI = MPIBlockDiag(ops=[Op, ])
@@ -166,8 +166,8 @@ def test_power(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2)])
-def test_sum(par):
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
+def test_sum_nccl(par):
     """Test the SumLinearOperator"""
     Op1 = pylops.MatrixMult(A=((rank + 1) * cp.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
     BDiag_MPI_1 = MPIBlockDiag(ops=[Op1, ])
@@ -206,8 +206,8 @@ def test_sum(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2)])
-def test_product(par):
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
+def test_product_nccl(par):
     """Test ProductLinearOperator"""
     Op1 = pylops.MatrixMult(A=((rank + 1) * cp.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
     BDiag_MPI_1 = MPIBlockDiag(ops=[Op1, ])
@@ -246,8 +246,8 @@ def test_product(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2)])
-def test_conj(par):
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
+def test_conj_nccl(par):
     """Test the ConjLinearOperator"""
     Op = pylops.MatrixMult(A=((rank + 1) * cp.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
     BDiag_MPI = MPIBlockDiag(ops=[Op, ])
@@ -280,8 +280,8 @@ def test_conj(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2)])
-def test_mpilinop(par):
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
+def test_mpilinop_nccl(par):
     """Wrapping the Pylops Linear Operator"""
     Fop = pylops.FirstDerivative(dims=(par['ny'], par['nx']), axis=0, dtype=par['dtype'])
     Mop = asmpilinearoperator(Op=Fop)
@@ -310,8 +310,8 @@ def test_mpilinop(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2)])
-def test_fwd_mpilinop(par):
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
+def test_fwd_mpilinop_nccl(par):
     """Test MPILinearOperator with other basic operators
         Matrix-Vector Product
     """
@@ -339,8 +339,8 @@ def test_fwd_mpilinop(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2)])
-def test_adj_mpilinop(par):
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
+def test_adj_mpilinop_nccl(par):
     """Test MPILinearOperator with other basic operators
         Adjoint Matrix-Vector Product
     """

--- a/tests_nccl/test_ncclutils_nccl.py
+++ b/tests_nccl/test_ncclutils_nccl.py
@@ -83,7 +83,7 @@ def test_allgather_differentsize_withrecbuf(par):
 
     # Gathered array
     send_shapes = MPI.COMM_WORLD.allgather(local_array.shape)
-    (send_buf, recv_buf) = _prepare_nccl_allgather_inputs(local_array, send_shapes)
+    send_buf, recv_buf = _prepare_nccl_allgather_inputs(local_array, send_shapes)
     recv_buf = nccl_allgather(nccl_comm, send_buf, recv_buf)
     chunks = _unroll_nccl_allgather_recv(recv_buf, send_buf.shape, send_shapes)
     gathered_array = cp.concatenate(chunks)

--- a/tests_nccl/test_ncclutils_nccl.py
+++ b/tests_nccl/test_ncclutils_nccl.py
@@ -1,0 +1,102 @@
+"""Test basic NCCL functionalities in _nccl
+Designed to run with n GPUs (with 1 MPI process per GPU)
+$ mpiexec -n 10 pytest test_ncclutils_nccl.py --with-mpi
+"""
+from mpi4py import MPI
+import numpy as np
+import cupy as cp
+from numpy.testing import assert_allclose
+import pytest
+
+from pylops_mpi.utils._nccl import initialize_nccl_comm, nccl_allgather, _prepare_nccl_allgather_inputs, _unroll_nccl_allgather_recv
+
+np.random.seed(42)
+
+nccl_comm = initialize_nccl_comm()
+
+par1 = {'n': 3, 'dtype': np.float64}
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), ])
+def test_allgather_samesize(par):
+    """Test nccl_allgather with arrays of same size"""
+    size = MPI.COMM_WORLD.Get_size()
+    rank = MPI.COMM_WORLD.Get_rank()
+
+    # Local array
+    local_array = rank * cp.ones(par['n'], dtype=par['dtype'])
+
+    # Gathered array
+    gathered_array = nccl_allgather(nccl_comm, local_array)
+
+    # Compare with global array created in rank0
+    if rank == 0:
+        global_array = np.ones(par['n'] * size, dtype=par['dtype'])
+        for irank in range(size):
+            global_array[irank * par["n"]: (irank + 1) * par["n"]] = irank
+
+        assert_allclose(
+            gathered_array.get(),
+            global_array,
+            rtol=1e-14,
+        )
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), ])
+def test_allgather_samesize_withrecbuf(par):
+    """Test nccl_allgather with arrays of same size and rec_buf"""
+    size = MPI.COMM_WORLD.Get_size()
+    rank = MPI.COMM_WORLD.Get_rank()
+
+    # Local array
+    local_array = rank * cp.ones(par['n'], dtype=par['dtype'])
+
+    # Gathered array
+    gathered_array = cp.zeros(par['n'] * size, dtype=par['dtype'])
+    gathered_array = nccl_allgather(nccl_comm, local_array, recv_buf=gathered_array)
+
+    # Compare with global array created in rank0
+    if rank == 0:
+        global_array = np.ones(par['n'] * size, dtype=par['dtype'])
+        for irank in range(size):
+            global_array[irank * par["n"]: (irank + 1) * par["n"]] = irank
+
+        assert_allclose(
+            gathered_array.get(),
+            global_array,
+            rtol=1e-14,
+        )
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), ])
+def test_allgather_differentsize_withrecbuf(par):
+    """Test nccl_allgather with arrays of different size and rec_buf"""
+    size = MPI.COMM_WORLD.Get_size()
+    rank = MPI.COMM_WORLD.Get_rank()
+
+    # Local array
+    n = par['n'] + (1 if rank == size - 1 else 0)
+    local_array = rank * cp.ones(n, dtype=par['dtype'])
+
+    # Gathered array
+    send_shapes = MPI.COMM_WORLD.allgather(local_array.shape)
+    (send_buf, recv_buf) = _prepare_nccl_allgather_inputs(local_array, send_shapes)
+    recv_buf = nccl_allgather(nccl_comm, send_buf, recv_buf)
+    chunks = _unroll_nccl_allgather_recv(recv_buf, send_buf.shape, send_shapes)
+    gathered_array = cp.concatenate(chunks)
+
+    # Compare with global array created in rank0
+    if rank == 0:
+        global_array = np.ones(par['n'] * size + 1, dtype=par['dtype'])
+        for irank in range(size - 1):
+            global_array[irank * par["n"]: (irank + 1) * par["n"]] = irank
+        global_array[(size - 1) * par["n"]:] = size - 1
+
+        assert_allclose(
+            gathered_array.get(),
+            global_array,
+            rtol=1e-14,
+        )

--- a/tests_nccl/test_solver_nccl.py
+++ b/tests_nccl/test_solver_nccl.py
@@ -65,40 +65,39 @@ par4 = {
     "x0": True,
     "dtype": "float64",
 }  # overdetermined real, non-zero initial guess
-
-# par1j = {
-#     "ny": 11,
-#     "nx": 11,
-#     "imag": 1j,
-#     "x0": False,
-#     "dtype": "complex128",
-# }  # square complex, zero initial guess
-# par2j = {
-#     "ny": 11,
-#     "nx": 11,
-#     "imag": 1j,
-#     "x0": True,
-#     "dtype": "complex128",
-# }  # square complex, non-zero initial guess
-# par3j = {
-#     "ny": 31,
-#     "nx": 11,
-#     "imag": 1j,
-#     "x0": False,
-#     "dtype": "complex128",
-# }  # overdetermined complex, zero initial guess
-# par4j = {
-#     "ny": 31,
-#     "nx": 11,
-#     "imag": 1j,
-#     "x0": True,
-#     "dtype": "complex128",
-# }  # overdetermined complex, non-zero initial guess
+par1j = {
+    "ny": 11,
+    "nx": 11,
+    "imag": 1j,
+    "x0": False,
+    "dtype": "complex128",
+}  # square complex, zero initial guess
+par2j = {
+    "ny": 11,
+    "nx": 11,
+    "imag": 1j,
+    "x0": True,
+    "dtype": "complex128",
+}  # square complex, non-zero initial guess
+par3j = {
+    "ny": 31,
+    "nx": 11,
+    "imag": 1j,
+    "x0": False,
+    "dtype": "complex128",
+}  # overdetermined complex, zero initial guess
+par4j = {
+    "ny": 31,
+    "nx": 11,
+    "imag": 1j,
+    "x0": True,
+    "dtype": "complex128",
+}  # overdetermined complex, non-zero initial guess
 
 
 @pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize(
-    "par", [(par1), (par2), (par3), (par4)]
+    "par", [(par1), (par1j), (par2), (par2j), (par3), (par3j), (par4), (par4j)]
 )
 def test_cg_nccl(par):
     """CG with MPIBlockDiag"""
@@ -143,7 +142,7 @@ def test_cg_nccl(par):
 
 @pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize(
-    "par", [(par1), (par2), (par3), (par4)]
+    "par", [(par1), (par1j), (par2), (par2j), (par3), (par3j), (par4), (par4j)]
 )
 def test_cgls_nccl(par):
     """CGLS with MPIBlockDiag"""
@@ -190,7 +189,7 @@ def test_cgls_nccl(par):
 
 @pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize(
-    "par", [(par1), (par2), (par3), (par4)]
+    "par", [(par1), (par1j), (par2), (par2j), (par3), (par3j), (par4), (par4j)]
 )
 def test_cgls_broadcastdata_nccl(par):
     """CGLS with broadcasted data vector"""
@@ -236,7 +235,7 @@ def test_cgls_broadcastdata_nccl(par):
 
 @pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize(
-    "par", [(par1), (par2), (par3), (par4)]
+    "par", [(par1), (par1j), (par2), (par2j), (par3), (par3j), (par4), (par4j)]
 )
 def test_cgls_broadcastmodel_nccl(par):
     """CGLS with broadcasted model vector"""
@@ -285,7 +284,7 @@ def test_cgls_broadcastmodel_nccl(par):
 
 @pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize(
-    "par", [(par1), (par2), (par3), (par4)]
+    "par", [(par1), (par1j), (par2), (par2j), (par3), (par3j), (par4), (par4j)]
 )
 def test_cg_stacked_nccl(par):
     """CG with MPIStackedBlockDiag"""
@@ -348,7 +347,7 @@ def test_cg_stacked_nccl(par):
 
 @pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize(
-    "par", [(par1), (par2), (par3), (par4)]
+    "par", [(par1), (par1j), (par2), (par2j), (par3), (par3j), (par4), (par4j)]
 )
 def test_cgls_stacked_nccl(par):
     """CGLS with MPIStackedBlockDiag"""

--- a/tests_nccl/test_stack_nccl.py
+++ b/tests_nccl/test_stack_nccl.py
@@ -17,13 +17,14 @@ from pylops_mpi.utils._nccl import initialize_nccl_comm
 
 nccl_comm = initialize_nccl_comm()
 
-# imag part is left to future complex-number support
 par1 = {'ny': 101, 'nx': 101, 'imag': 0, 'dtype': np.float64}
+par1j = {'ny': 101, 'nx': 101, 'imag': 1j, 'dtype': np.complex128}
 par2 = {'ny': 301, 'nx': 101, 'imag': 0, 'dtype': np.float64}
+par2j = {'ny': 301, 'nx': 101, 'imag': 1j, 'dtype': np.complex128}
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
 def test_vstack_nccl(par):
     """Test the MPIVStack operator with NCCL"""
     size = MPI.COMM_WORLD.Get_size()
@@ -73,7 +74,7 @@ def test_vstack_nccl(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
 def test_stacked_vstack_nccl(par):
     """Test the MPIStackedVStack operator with NCCL"""
     size = MPI.COMM_WORLD.Get_size()
@@ -120,7 +121,7 @@ def test_stacked_vstack_nccl(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
 def test_hstack_nccl(par):
     """Test the MPIHStack operator with NCCL"""
     size = MPI.COMM_WORLD.Get_size()

--- a/tests_nccl/test_stackedarray_nccl.py
+++ b/tests_nccl/test_stackedarray_nccl.py
@@ -19,27 +19,28 @@ np.random.seed(42)
 par1 = {'global_shape': (500, 501),
         'partition': Partition.SCATTER, 'dtype': np.float64,
         'axis': 1}
-# par1j = {'global_shape': (501, 500),
-#          'partition': Partition.SCATTER, 'dtype': np.complex128,
-#          'axis': 0}
+par1j = {'global_shape': (501, 500),
+         'partition': Partition.SCATTER, 'dtype': np.complex128,
+         'axis': 0}
 par2 = {'global_shape': (500, 501),
         'partition': Partition.BROADCAST, 'dtype': np.float64,
         'axis': 1}
-# par2j = {'global_shape': (501, 500),
-#          'partition': Partition.BROADCAST, 'dtype': np.complex128,
-#          'axis': 0}
+par2j = {'global_shape': (501, 500),
+         'partition': Partition.BROADCAST, 'dtype': np.complex128,
+         'axis': 0}
 
 par3 = {'global_shape': (200, 201, 101),
         'partition': Partition.SCATTER,
         'dtype': np.float64, 'axis': 1}
 
-# par3j = {'global_shape': (200, 201, 101),
-#          'partition': Partition.SCATTER,
-#          'dtype': np.complex128, 'axis': 2}
+par3j = {'global_shape': (200, 201, 101),
+         'partition': Partition.SCATTER,
+         'dtype': np.complex128, 'axis': 2}
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2), (par3),])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2),
+                                 (par2j), (par3), (par3j)])
 def test_creation_nccl(par):
     """Test creation of stacked distributed arrays"""
     # Create stacked array
@@ -73,7 +74,8 @@ def test_creation_nccl(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2), (par3)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2),
+                                 (par2j), (par3), (par3j)])
 def test_stacked_math_nccl(par):
     """Test the Element-Wise Addition, Subtraction and Multiplication, Dot-product, Norm"""
     distributed_array0 = DistributedArray(global_shape=par['global_shape'],

--- a/tests_nccl/test_stackedlinearop_nccl.py
+++ b/tests_nccl/test_stackedlinearop_nccl.py
@@ -21,13 +21,13 @@ rank = MPI.COMM_WORLD.Get_rank()
 size = MPI.COMM_WORLD.Get_size()
 
 par1 = {'ny': 101, 'nx': 101, 'dtype': np.float64}
-# par1j = {'ny': 101, 'nx': 101, 'dtype': np.complex128}
+par1j = {'ny': 101, 'nx': 101, 'dtype': np.complex128}
 par2 = {'ny': 301, 'nx': 101, 'dtype': np.float64}
-# par2j = {'ny': 301, 'nx': 101, 'dtype': np.complex128}
+par2j = {'ny': 301, 'nx': 101, 'dtype': np.complex128}
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
 def test_stackedlinearop_nccl(par):
     """Apply various overloaded operators (.H, .T, +, *, conj()) and ensure that the
     returned operator is still of `pylops_mpi.MPIStackedLinearOperator` type
@@ -47,7 +47,7 @@ def test_stackedlinearop_nccl(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
 def test_transpose_nccl(par):
     """Test the StackedTransposeLinearOperator"""
     Op = pylops.MatrixMult(A=((rank + 1) * cp.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
@@ -90,7 +90,7 @@ def test_transpose_nccl(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
 def test_scaled_nccl(par):
     """Test the StackedScaledLinearOperator"""
     Op = pylops.MatrixMult(A=((rank + 1) * cp.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
@@ -133,7 +133,7 @@ def test_scaled_nccl(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
 def test_conj_nccl(par):
     """Test the StackedConjLinearOperator"""
     Op = pylops.MatrixMult(A=((rank + 1) * cp.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
@@ -176,7 +176,7 @@ def test_conj_nccl(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
 def test_power_nccl(par):
     """Test the StackedPowerLinearOperator"""
     Op = pylops.MatrixMult(A=((rank + 1) * cp.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
@@ -219,7 +219,7 @@ def test_power_nccl(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
 def test_sum_nccl(par):
     """Test the StackedSumLinearOperator"""
     Op1 = pylops.MatrixMult(A=((rank + 1) * cp.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))
@@ -271,7 +271,7 @@ def test_sum_nccl(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j)])
 def test_product_nccl(par):
     """Test the StackedProductLinearOperator"""
     Op1 = pylops.MatrixMult(A=((rank + 1) * cp.ones(shape=(par['ny'], par['nx']))).astype(par['dtype']))


### PR DESCRIPTION
I introduce the complex number support for NCCL communication here.

Changes made:
- `_nccl.py`  - Previously, the number of elements sent is equivalent to the number of elements in the `send_buf`. To support the complex number, we can simply send 2x of that size (`_nccl_buf_size()`). The receiving data layout does not need changes as it will be according to the `recv_buf`  i.e., it will already  be complex if `send_buf` is complex.

- test files - I enabled all the tests. Some were muted earlier due to lack of complex-number support. Now the NCCL and MPI both have 306 tests.

- `Fredholm1.py` - This likely needs some discussion (please see TODO: comment). Particularly, the private function `_allgather` is called because Ops do not take `base_comm_nccl` as an argument. Also, Fredholm operator needs some array unrolling in `_rmatvec`

Testing:
- As mentioned, now both NCCL+CuPy and MPI+NumPy cover 306 tests.