### PR TITLE
Syn before record the time in mark

### DIFF
--- a/pylops_mpi/utils/benchmark.py
+++ b/pylops_mpi/utils/benchmark.py
@@ -133,6 +133,7 @@ def benchmark(func: Optional[Callable] = None,
             header_index = len(_markers) - 1
 
             def local_mark(label):
+                _sync()
                 _markers.append((label, time.perf_counter(), level))
 
             _mark_func_stack.append(local_mark)


### PR DESCRIPTION
This PR fixes the bug inn `benchmark.py`
It does not synchronize the GPUs correctly in the call to `mark()`.
The current implementation synchronizes correctly at the top level, i.e., the decorated function, through the sandwich of `_sync()` before and after the start and end time measurements.

The call to `mark()` should also have synchronization. Without this, I observe that in the benchmark to the simple function shown below, it will give about the same time measured regardless of the input size (1MB - 8GB) in the NCCL environment.

```
@benchmark(logger=logger)
def run_allreduce_bench(par):
    # <--snip-->
    mark("Start")
    dist_arr._allreduce(dist_arr.local_array)
    # <-- GPU run allreduce in an async manner.
    # So, the CPU may race ahead and call mark
    # without waiting for GPUs to finish
    mark("End allreduce")

