### PR TITLE
Add `dims` and `dimsd` to MPI Operators

### DIFF
--- a/docs/source/adding.rst
+++ b/docs/source/adding.rst
@@ -65,6 +65,14 @@ while the ``base_comm`` is set to ``MPI.COMM_WORLD`` if not provided.
         dtype = _get_dtype(ops) if dtype is None else np.dtype(dtype)
         super().__init__(shape=shape, dtype=dtype, base_comm=base_comm)
 
+Every :py:class:`pylops_mpi.MPILinearOperator` class is equipped with ``dims`` and ``dimsd``, in
+addition to the required ``dtype``, ``shape``, and ``base_comm``. Note that ``dims`` and ``dimsd`` can
+be defined independently of ``shape``, which will then be automatically assigned within the
+``super`` method.
+
+See the docs of :py:class:`pylops_mpi.MPILinearOperator` for more information about what these
+attributes mean.
+
 Forward mode (``_matvec``)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 We can then move onto writing the *forward mode* in the method ``_matvec``. In other words, we will need to write

--- a/pylops_mpi/LinearOperator.py
+++ b/pylops_mpi/LinearOperator.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import numpy as np
 from mpi4py import MPI
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 
 from scipy.sparse._sputils import isintlike
 from scipy.sparse.linalg._interface import _get_dtype
@@ -26,15 +28,19 @@ class MPILinearOperator:
     Note that whilst this operator could also be used with different
     :obj:`pylops.LinearOperator` across ranks, and with a
     :class:`pylops_mpi.DistributedArray` with ``Partition.SCATTER``, it is however
-    reccomended to use the :class:`pylops_mpi.basicoperators.MPIBlockDiag` operator
+    recommended to use the :class:`pylops_mpi.basicoperators.MPIBlockDiag` operator
     instead as this can also handle distributed arrays with subcommunicators.
 
     Parameters
     ----------
-    Op : :obj:`pylops.LinearOperator`, optional
-        PyLops Linear Operator to wrap. Defaults to ``None``.
+    Op : :obj:`pylops.LinearOperator` or :obj:`pylops_mpi.MPILinearOperator`, optional
+        If other arguments are provided, they will overwrite those obtained from ``Op``. Defaults to ``None``.
     shape : :obj:`tuple(int, int)`, optional
-        Shape of the MPI Linear Operator. Defaults to ``None``.
+        Shape of the MPI Linear Operator. If not provided, obtained from ``dims`` and ``dimsd``.
+    dims : :obj:`tuple(int, ..., int)`, optional
+        Dimensions of model. If not provided, ``(self.shape[1],)`` is used.
+    dimsd : :obj:`tuple(int, ..., int)`, optional
+        Dimensions of data. If not provided, ``(self.shape[0],)`` is used.
     dtype : :obj:`str`, optional
         Type of elements in input array. Defaults to ``None``.
     base_comm : :obj:`mpi4py.MPI.Comm`, optional
@@ -42,20 +48,38 @@ class MPILinearOperator:
 
     """
 
-    def __init__(self, Op: Optional[LinearOperator] = None, shape: Optional[ShapeLike] = None,
-                 dtype: Optional[DTypeLike] = None, base_comm: MPI.Comm = MPI.COMM_WORLD):
-        if Op:
+    def __init__(
+        self,
+        Op: Optional[Union[LinearOperator, MPILinearOperator]] = None,
+        shape: Optional[ShapeLike] = None,
+        dims: Optional[ShapeLike] = None,
+        dimsd: Optional[ShapeLike] = None,
+        dtype: Optional[DTypeLike] = None,
+        base_comm: MPI.Comm = MPI.COMM_WORLD
+    ):
+        if Op is not None:
             self.Op = Op
-            dtype = self.Op.dtype if dtype is None else dtype
-            shape = self.Op.shape if shape is None else shape
-        if shape:
-            self.shape = shape
-        if dtype:
-            self.dtype = dtype
+            dtype = Op.dtype if dtype is None else dtype
+            shape = Op.shape if shape is None else shape
+            # Optional arguments
+            dims = getattr(Op, "dims", None) if dims is None else dims
+            dimsd = getattr(Op, "dimsd", None) if dimsd is None else dimsd
+
+        # Infer shape from dims/dimsd if not provided
+        if shape is None:
+            if dims is None or dimsd is None:
+                raise ValueError(
+                    "Must provide either 'shape' or both 'dims' and 'dimsd'"
+                )
+            shape = (int(np.prod(dimsd)), int(np.prod(dims)))
+        self.shape = shape
+        self.dims = (shape[1],) if dims is None else dims
+        self.dimsd = (shape[0],) if dimsd is None else dimsd
+        self.dtype = dtype
         # For MPI
         self.base_comm = base_comm
-        self.size = self.base_comm.Get_size()
-        self.rank = self.base_comm.Get_rank()
+        self.size = base_comm.Get_size()
+        self.rank = base_comm.Get_rank()
 
     def matvec(self, x: DistributedArray) -> DistributedArray:
         """Matrix-vector multiplication.

--- a/pylops_mpi/LinearOperator.py
+++ b/pylops_mpi/LinearOperator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 from mpi4py import MPI
 from typing import Callable, Optional
@@ -254,9 +256,19 @@ class MPILinearOperator:
 
         """
         if isinstance(x, MPILinearOperator):
-            return _ProductLinearOperator(self, x)
+            Op = _ProductLinearOperator(self, x)
+            self._copy_attributes(
+                Op,
+                exclude=['dims']
+            )
+            Op.dims = x.dims
+            return Op
         elif np.isscalar(x):
-            return _ScaledLinearOperator(self, x)
+            Op = _ScaledLinearOperator(self, x)
+            self._copy_attributes(
+                Op
+            )
+            return Op
         else:
             if x is None or x.ndim == 1:
                 return self.matvec(x)
@@ -297,7 +309,11 @@ class MPILinearOperator:
 
     def __rmul__(self, x):
         if np.isscalar(x):
-            return _ScaledLinearOperator(self, x)
+            Op = _ScaledLinearOperator(self, x)
+            self._copy_attributes(
+                Op
+            )
+            return Op
         else:
             return NotImplemented
 
@@ -312,22 +328,48 @@ class MPILinearOperator:
         return self.__rmul__(x)
 
     def __pow__(self, p):
-        return _PowerLinearOperator(self, p)
+        Op = _PowerLinearOperator(self, p)
+        self._copy_attributes(
+            Op
+        )
+        return Op
 
     def __add__(self, x):
-        return _SumLinearOperator(self, x)
+        Op = _SumLinearOperator(self, x)
+        self._copy_attributes(
+            Op
+        )
+        return Op
 
     def __neg__(self):
-        return _ScaledLinearOperator(self, -1)
+        Op = _ScaledLinearOperator(self, -1)
+        self._copy_attributes(
+            Op
+        )
+        return Op
 
     def __sub__(self, x):
         return self.__add__(-x)
 
     def _adjoint(self):
-        return _AdjointLinearOperator(self)
+        Op = _AdjointLinearOperator(self)
+        self._copy_attributes(
+            Op,
+            exclude=['dims', 'dimsd']
+        )
+        Op.dims = self.dimsd
+        Op.dimsd = self.dims
+        return Op
 
     def _transpose(self):
-        return _TransposedLinearOperator(self)
+        Op = _TransposedLinearOperator(self)
+        self._copy_attributes(
+            Op,
+            exclude=['dims', 'dimsd']
+        )
+        Op.dims = self.dimsd
+        Op.dimsd = self.dims
+        return Op
 
     def conj(self):
         """Complex conjugate operator
@@ -339,6 +381,20 @@ class MPILinearOperator:
 
         """
         return _ConjLinearOperator(self)
+
+    def _copy_attributes(
+        self,
+        dest: MPILinearOperator,
+        exclude: list[str] | None = None,
+    ) -> None:
+        """Copy attributes from one MPILinearOperator to another"""
+        attrs = ["dims", "dimsd"]
+        if exclude is not None:
+            for item in exclude:
+                attrs.remove(item)
+        for attr in attrs:
+            if hasattr(self, attr):
+                setattr(dest, attr, getattr(self, attr))
 
     def __repr__(self):
         M, N = self.shape

--- a/pylops_mpi/LinearOperator.py
+++ b/pylops_mpi/LinearOperator.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import numpy as np
 from mpi4py import MPI
-from typing import Callable, Optional, Union
+from typing import Callable, Optional
 
-from scipy.sparse._sputils import isintlike
+from scipy.sparse._sputils import isintlike, isshape
 from scipy.sparse.linalg._interface import _get_dtype
 
 from pylops import LinearOperator
@@ -33,7 +33,7 @@ class MPILinearOperator:
 
     Parameters
     ----------
-    Op : :obj:`pylops.LinearOperator` or :obj:`pylops_mpi.MPILinearOperator`, optional
+    Op : :obj:`pylops.LinearOperator`, optional
         If other arguments are provided, they will overwrite those obtained from ``Op``. Defaults to ``None``.
     shape : :obj:`tuple(int, int)`, optional
         Shape of the MPI Linear Operator. If not provided, obtained from ``dims`` and ``dimsd``.
@@ -50,7 +50,7 @@ class MPILinearOperator:
 
     def __init__(
         self,
-        Op: Optional[Union[LinearOperator, MPILinearOperator]] = None,
+        Op: Optional[LinearOperator] = None,
         shape: Optional[ShapeLike] = None,
         dims: Optional[ShapeLike] = None,
         dimsd: Optional[ShapeLike] = None,
@@ -62,24 +62,110 @@ class MPILinearOperator:
             dtype = Op.dtype if dtype is None else dtype
             shape = Op.shape if shape is None else shape
             # Optional arguments
-            dims = getattr(Op, "dims", None) if dims is None else dims
-            dimsd = getattr(Op, "dimsd", None) if dimsd is None else dimsd
-
-        # Infer shape from dims/dimsd if not provided
-        if shape is None:
-            if dims is None or dimsd is None:
-                raise ValueError(
-                    "Must provide either 'shape' or both 'dims' and 'dimsd'"
-                )
-            shape = (int(np.prod(dimsd)), int(np.prod(dims)))
-        self.shape = shape
-        self.dims = (shape[1],) if dims is None else dims
-        self.dimsd = (shape[0],) if dimsd is None else dimsd
-        self.dtype = dtype
+            dims = getattr(Op, "dims", (Op.shape[1], )) if dims is None else dims
+            dimsd = getattr(Op, "dimsd", (Op.shape[0], )) if dimsd is None else dimsd
+        if shape is not None:
+            self.shape = shape
+        if dims is not None:
+            self.dims = dims
+        if dimsd is not None:
+            self.dimsd = dimsd
+        if dtype is not None:
+            self.dtype = dtype
         # For MPI
         self.base_comm = base_comm
         self.size = base_comm.Get_size()
         self.rank = base_comm.Get_rank()
+
+    @property
+    def shape(self):
+        _shape = getattr(self, "_shape", None)
+        if _shape is None:  # Cannot find shape, falling back on dims and dimsd
+            dims = getattr(self, "_dims", None)
+            dimsd = getattr(self, "_dimsd", None)
+            if dims is None or dimsd is None:  # Cannot find both dims and dimsd, error
+                msg = (
+                    f"'{self.__class__.__name__}' object has no attribute 'shape' "
+                    "nor both fallback attributes ('dims', 'dimsd')"
+                )
+                raise AttributeError(msg)
+            _shape = (int(np.prod(dimsd)), int(np.prod(dims)))
+            self._shape = _shape  # Update to not redo everything above on next call
+        return _shape
+
+    @shape.setter
+    def shape(self, new_shape: ShapeLike) -> None:
+        new_shape = tuple(new_shape)
+        if not isshape(new_shape):
+            msg = f"Invalid shape; must be 2-d tuple of integers, got {new_shape}"
+            raise ValueError(msg)
+        dims = getattr(self, "_dims", None)
+        dimsd = getattr(self, "_dimsd", None)
+        if dims is not None and dimsd is not None:  # Found dims and dimsd
+            if np.prod(dimsd) != new_shape[0] and np.prod(dims) != new_shape[1]:
+                msg = "New shape incompatible with dims and dimsd"
+                raise ValueError(msg)
+            elif np.prod(dimsd) != new_shape[0]:
+                msg = "New shape incompatible with dimsd"
+                raise ValueError(msg)
+            elif np.prod(dims) != new_shape[1]:
+                msg = "New shape incompatible with dims"
+                raise ValueError(msg)
+        self._shape = new_shape
+
+    @property
+    def dims(self):
+        _dims = getattr(self, "_dims", None)
+        if _dims is None:
+            shape = getattr(self, "_shape", None)
+            if shape is None:
+                msg = (
+                    f"'{self.__class__.__name__}' object has no "
+                    "attributes 'dims' or 'shape'"
+                )
+                raise AttributeError(msg)
+            _dims = (shape[1],)
+        return _dims
+
+    @dims.setter
+    def dims(self, new_dims: ShapeLike) -> None:
+        new_dims = tuple(new_dims)
+        shape = getattr(self, "_shape", None)
+        if shape is None:  # shape not set yet
+            self._dims = new_dims
+        else:
+            if np.prod(new_dims) == self.shape[1]:
+                self._dims = new_dims
+            else:
+                msg = "dims incompatible with shape[1]"
+                raise ValueError(msg)
+
+    @property
+    def dimsd(self):
+        _dimsd = getattr(self, "_dimsd", None)
+        if _dimsd is None:
+            shape = getattr(self, "_shape", None)
+            if shape is None:
+                msg = (
+                    f"'{self.__class__.__name__}' object has "
+                    "no attributes 'dimsd' or 'shape'"
+                )
+                raise AttributeError(msg)
+            _dimsd = (shape[0],)
+        return _dimsd
+
+    @dimsd.setter
+    def dimsd(self, new_dimsd: ShapeLike) -> None:
+        new_dimsd = tuple(new_dimsd)
+        shape = getattr(self, "_shape", None)
+        if shape is None:  # shape not set yet
+            self._dimsd = new_dimsd
+        else:
+            if np.prod(new_dimsd) == self.shape[0]:
+                self._dimsd = new_dimsd
+            else:
+                msg = "dimsd incompatible with shape[0]"
+                raise ValueError(msg)
 
     def matvec(self, x: DistributedArray) -> DistributedArray:
         """Matrix-vector multiplication.

--- a/pylops_mpi/LinearOperator.py
+++ b/pylops_mpi/LinearOperator.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import numpy as np
 from mpi4py import MPI
 from typing import Callable, Optional

--- a/pylops_mpi/StackedLinearOperator.py
+++ b/pylops_mpi/StackedLinearOperator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Union, Callable
 from abc import abstractmethod, ABC
 import numpy as np
@@ -141,7 +143,6 @@ class MPIStackedLinearOperator(ABC):
 
     @dimsd.setter
     def dimsd(self, new_dimsd: ShapeLike) -> None:
-        print("This is ", new_dimsd)
         new_dimsd = tuple(new_dimsd)
         shape = getattr(self, "_shape", None)
         if shape is None:  # shape not set yet
@@ -236,9 +237,19 @@ class MPIStackedLinearOperator(ABC):
 
         """
         if isinstance(x, MPIStackedLinearOperator):
-            return _ProductStackedLinearOperator(self, x)
+            Op = _ProductStackedLinearOperator(self, x)
+            self._copy_attributes(
+                Op,
+                exclude=['dims']
+            )
+            Op.dims = x.dims
+            return Op
         elif np.isscalar(x):
-            return _ScaledStackedLinearOperator(self, x)
+            Op = _ScaledStackedLinearOperator(self, x)
+            self._copy_attributes(
+                Op
+            )
+            return Op
         else:
             if x is None or (isinstance(x, DistributedArray) and x.ndim == 1):
                 return self.matvec(x)
@@ -280,7 +291,11 @@ class MPIStackedLinearOperator(ABC):
 
     def __rmul__(self, x):
         if np.isscalar(x):
-            return _ScaledStackedLinearOperator(self, x)
+            Op = _ScaledStackedLinearOperator(self, x)
+            self._copy_attributes(
+                Op
+            )
+            return Op
         else:
             return NotImplemented
 
@@ -295,22 +310,48 @@ class MPIStackedLinearOperator(ABC):
         return self.__rmul__(x)
 
     def __pow__(self, p):
-        return _PowerLinearOperator(self, p)
+        Op = _PowerLinearOperator(self, p)
+        self._copy_attributes(
+            Op
+        )
+        return Op
 
     def __add__(self, x):
-        return _SumStackedLinearOperator(self, x)
+        Op = _SumStackedLinearOperator(self, x)
+        self._copy_attributes(
+            Op
+        )
+        return Op
 
     def __neg__(self):
-        return _ScaledStackedLinearOperator(self, -1)
+        Op = _ScaledStackedLinearOperator(self, -1)
+        self._copy_attributes(
+            Op
+        )
+        return Op
 
     def __sub__(self, x):
         return self.__add__(-x)
 
     def _adjoint(self):
-        return _AdjointStackedLinearOperator(self)
+        Op = _AdjointStackedLinearOperator(self)
+        self._copy_attributes(
+            Op,
+            exclude=['dims', 'dimsd']
+        )
+        Op.dims = self.dimsd
+        Op.dimsd = self.dims
+        return Op
 
     def _transpose(self):
-        return _TransposedStackedLinearOperator(self)
+        Op = _TransposedStackedLinearOperator(self)
+        self._copy_attributes(
+            Op,
+            exclude=['dims', 'dimsd']
+        )
+        Op.dims = self.dimsd
+        Op.dimsd = self.dims
+        return Op
 
     def conj(self):
         """Complex conjugate operator
@@ -330,6 +371,20 @@ class MPIStackedLinearOperator(ABC):
         else:
             dt = f"dtype={self.dtype}"
         return f"<{M}x{N} {self.__class__.__name__} with {dt}>"
+
+    def _copy_attributes(
+        self,
+        dest: MPIStackedLinearOperator,
+        exclude: list[str] | None = None,
+    ) -> None:
+        """Copy attributes from one MPIStackedLinearOperator to another"""
+        attrs = ["dims", "dimsd"]
+        if exclude is not None:
+            for item in exclude:
+                attrs.remove(item)
+        for attr in attrs:
+            if hasattr(self, attr):
+                setattr(dest, attr, getattr(self, attr))
 
 
 class _AdjointStackedLinearOperator(MPIStackedLinearOperator):

--- a/pylops_mpi/StackedLinearOperator.py
+++ b/pylops_mpi/StackedLinearOperator.py
@@ -4,7 +4,7 @@ import numpy as np
 from mpi4py import MPI
 from pylops.utils import ShapeLike, DTypeLike
 
-from scipy.sparse._sputils import isintlike
+from scipy.sparse._sputils import isintlike, isshape
 from scipy.sparse.linalg._interface import _get_dtype
 
 from pylops_mpi.DistributedArray import DistributedArray, StackedDistributedArray
@@ -49,20 +49,109 @@ class MPIStackedLinearOperator(ABC):
         base_comm: MPI.Comm = MPI.COMM_WORLD
     ):
         # Infer shape from dims/dimsd if not provided
-        if shape is None:
-            if dims is None or dimsd is None:
-                raise ValueError(
-                    "Must provide either 'shape' or both 'dims' and 'dimsd'"
-                )
-            shape = (int(np.prod(dimsd)), int(np.prod(dims)))
-        self.shape = shape
-        self.dims = (shape[1],) if dims is None else dims
-        self.dimsd = (shape[0],) if dimsd is None else dimsd
-        self.dtype = dtype
+        if shape is not None:
+            self.shape = shape
+        if dims is not None:
+            self.dims = dims
+        if dimsd is not None:
+            self.dimsd = dimsd
+        if dtype is not None:
+            self.dtype = dtype
         # For MPI
         self.base_comm = base_comm
         self.size = base_comm.Get_size()
         self.rank = base_comm.Get_rank()
+
+    @property
+    def shape(self):
+        _shape = getattr(self, "_shape", None)
+        if _shape is None:  # Cannot find shape, falling back on dims and dimsd
+            dims = getattr(self, "_dims", None)
+            dimsd = getattr(self, "_dimsd", None)
+            if dims is None or dimsd is None:  # Cannot find both dims and dimsd, error
+                msg = (
+                    f"'{self.__class__.__name__}' object has no attribute 'shape' "
+                    "nor both fallback attributes ('dims', 'dimsd')"
+                )
+                raise AttributeError(msg)
+            _shape = (int(np.prod(dimsd)), int(np.prod(dims)))
+            self._shape = _shape  # Update to not redo everything above on next call
+        return _shape
+
+    @shape.setter
+    def shape(self, new_shape: ShapeLike) -> None:
+        new_shape = tuple(new_shape)
+        if not isshape(new_shape):
+            msg = f"Invalid shape; must be 2-d tuple of integers, got {new_shape}"
+            raise ValueError(msg)
+        dims = getattr(self, "_dims", None)
+        dimsd = getattr(self, "_dimsd", None)
+        if dims is not None and dimsd is not None:  # Found dims and dimsd
+            if np.prod(dimsd) != new_shape[0] and np.prod(dims) != new_shape[1]:
+                msg = "New shape incompatible with dims and dimsd"
+                raise ValueError(msg)
+            elif np.prod(dimsd) != new_shape[0]:
+                msg = "New shape incompatible with dimsd"
+                raise ValueError(msg)
+            elif np.prod(dims) != new_shape[1]:
+                msg = "New shape incompatible with dims"
+                raise ValueError(msg)
+        self._shape = new_shape
+
+    @property
+    def dims(self):
+        _dims = getattr(self, "_dims", None)
+        if _dims is None:
+            shape = getattr(self, "_shape", None)
+            if shape is None:
+                msg = (
+                    f"'{self.__class__.__name__}' object has no "
+                    "attributes 'dims' or 'shape'"
+                )
+                raise AttributeError(msg)
+            _dims = (shape[1],)
+        return _dims
+
+    @dims.setter
+    def dims(self, new_dims: ShapeLike) -> None:
+        new_dims = tuple(new_dims)
+        shape = getattr(self, "_shape", None)
+        if shape is None:  # shape not set yet
+            self._dims = new_dims
+        else:
+            if np.prod(new_dims) == self.shape[1]:
+                self._dims = new_dims
+            else:
+                msg = "dims incompatible with shape[1]"
+                raise ValueError(msg)
+
+    @property
+    def dimsd(self):
+        _dimsd = getattr(self, "_dimsd", None)
+        if _dimsd is None:
+            shape = getattr(self, "_shape", None)
+            if shape is None:
+                msg = (
+                    f"'{self.__class__.__name__}' object has "
+                    "no attributes 'dimsd' or 'shape'"
+                )
+                raise AttributeError(msg)
+            _dimsd = (shape[0],)
+        return _dimsd
+
+    @dimsd.setter
+    def dimsd(self, new_dimsd: ShapeLike) -> None:
+        print("This is ", new_dimsd)
+        new_dimsd = tuple(new_dimsd)
+        shape = getattr(self, "_shape", None)
+        if shape is None:  # shape not set yet
+            self._dimsd = new_dimsd
+        else:
+            if np.prod(new_dimsd) == self.shape[0]:
+                self._dimsd = new_dimsd
+            else:
+                msg = "dimsd incompatible with shape[0]"
+                raise ValueError(msg)
 
     def matvec(self, x: Union[DistributedArray, StackedDistributedArray]) -> Union[DistributedArray, StackedDistributedArray]:
         """Matrix-vector multiplication.

--- a/pylops_mpi/StackedLinearOperator.py
+++ b/pylops_mpi/StackedLinearOperator.py
@@ -29,24 +29,40 @@ class MPIStackedLinearOperator(ABC):
     Parameters
     ----------
     shape : :obj:`tuple(int, int)`, optional
-        Shape of the MPIStackedLinearOperator. Defaults to ``None``.
+        Shape of the MPIStackedLinearOperator. If not provided, obtained from ``dims`` and ``dimsd``.
+    dims : :obj:`tuple(int, ..., int)`, optional
+        Dimensions of model. If not provided, ``(self.shape[1],)`` is used.
+    dimsd : :obj:`tuple(int, ..., int)`, optional
+        Dimensions of data. If not provided, ``(self.shape[0],)`` is used.
     dtype : :obj:`str`, optional
         Type of elements in input array. Defaults to ``None``.
     base_comm : :obj:`mpi4py.MPI.Comm`, optional
         MPI Base Communicator. Defaults to ``mpi4py.MPI.COMM_WORLD``.
     """
 
-    def __init__(self, shape: Optional[ShapeLike] = None,
-                 dtype: Optional[DTypeLike] = None,
-                 base_comm: MPI.Comm = MPI.COMM_WORLD):
-        if shape:
-            self.shape = shape
-        if dtype:
-            self.dtype = dtype
+    def __init__(
+        self,
+        shape: Optional[ShapeLike] = None,
+        dims: Optional[ShapeLike] = None,
+        dimsd: Optional[ShapeLike] = None,
+        dtype: Optional[DTypeLike] = None,
+        base_comm: MPI.Comm = MPI.COMM_WORLD
+    ):
+        # Infer shape from dims/dimsd if not provided
+        if shape is None:
+            if dims is None or dimsd is None:
+                raise ValueError(
+                    "Must provide either 'shape' or both 'dims' and 'dimsd'"
+                )
+            shape = (int(np.prod(dimsd)), int(np.prod(dims)))
+        self.shape = shape
+        self.dims = (shape[1],) if dims is None else dims
+        self.dimsd = (shape[0],) if dimsd is None else dimsd
+        self.dtype = dtype
         # For MPI
         self.base_comm = base_comm
-        self.size = self.base_comm.Get_size()
-        self.rank = self.base_comm.Get_rank()
+        self.size = base_comm.Get_size()
+        self.rank = base_comm.Get_rank()
 
     def matvec(self, x: Union[DistributedArray, StackedDistributedArray]) -> Union[DistributedArray, StackedDistributedArray]:
         """Matrix-vector multiplication.

--- a/pylops_mpi/basicoperators/BlockDiag.py
+++ b/pylops_mpi/basicoperators/BlockDiag.py
@@ -114,9 +114,10 @@ class MPIBlockDiag(MPILinearOperator):
         self.local_shapes_n = base_comm.allgather((self.nops, ))
         self.nnops = np.insert(np.cumsum(nops), 0, 0)
         self.mmops = np.insert(np.cumsum(mops), 0, 0)
-        shape = (base_comm.allreduce(self.nops), base_comm.allreduce(self.mops))
+        dimsd = (base_comm.allreduce(self.nops), )
+        dims = (base_comm.allreduce(self.mops), )
         dtype = _get_dtype(ops) if dtype is None else np.dtype(dtype)
-        super().__init__(shape=shape, dtype=dtype, base_comm=base_comm)
+        super().__init__(dims=dims, dimsd=dimsd, dtype=dtype, base_comm=base_comm)
 
     @reshaped(forward=True, stacking=True)
     def _matvec(self, x: DistributedArray) -> DistributedArray:

--- a/pylops_mpi/basicoperators/BlockDiag.py
+++ b/pylops_mpi/basicoperators/BlockDiag.py
@@ -171,9 +171,9 @@ class MPIStackedBlockDiag(MPIStackedLinearOperator):
                  dtype: Optional[DTypeLike] = None):
         self.ops = ops
         dtype = _get_dtype(self.ops) if dtype is None else np.dtype(dtype)
-        shape = (int(sum(op.shape[0] for op in ops)),
-                 int(sum(op.shape[1] for op in ops)))
-        super().__init__(shape=shape, dtype=dtype, base_comm=base_comm)
+        dims = (int(sum(op.shape[1] for op in ops)), )
+        dimsd = (int(sum(op.shape[0] for op in ops)), )
+        super().__init__(dims=dims, dimsd=dimsd, dtype=dtype, base_comm=base_comm)
 
     def _matvec(self, x: StackedDistributedArray) -> StackedDistributedArray:
         y1 = []

--- a/pylops_mpi/basicoperators/FirstDerivative.py
+++ b/pylops_mpi/basicoperators/FirstDerivative.py
@@ -89,9 +89,8 @@ class MPIFirstDerivative(MPILinearOperator):
                  order: int = 3,
                  base_comm: MPI.Comm = MPI.COMM_WORLD,
                  dtype: DTypeLike = np.float64):
-        self.dims = _value_or_sized_to_tuple(dims)
-        shape = (int(np.prod(dims)),) * 2
-        super().__init__(shape=shape, dtype=np.dtype(dtype), base_comm=base_comm)
+        dims = _value_or_sized_to_tuple(dims)
+        super().__init__(dims=dims, dimsd=dims, dtype=np.dtype(dtype), base_comm=base_comm)
         self.sampling = sampling
         self.kind = kind
         self.edge = edge

--- a/pylops_mpi/basicoperators/Gradient.py
+++ b/pylops_mpi/basicoperators/Gradient.py
@@ -81,16 +81,15 @@ class MPIGradient(MPIStackedLinearOperator):
                  base_comm: MPI.Comm = MPI.COMM_WORLD,
                  dtype: DTypeLike = "float64",
                  ):
-        self.dims = _value_or_sized_to_tuple(dims)
-        ndims = len(self.dims)
-        sampling = _value_or_sized_to_tuple(sampling, repeat=ndims)
+        dims = _value_or_sized_to_tuple(dims)
+        sampling = _value_or_sized_to_tuple(sampling, repeat=len(dims))
         self.sampling = sampling
         self.edge = edge
         self.kind = kind
         self.base_comm = base_comm
         self.dtype = np.dtype(dtype)
-        self.Op = self._calc_stack_op(ndims)
-        super().__init__(shape=self.Op.shape, dtype=dtype, base_comm=base_comm)
+        self.Op = self._calc_stack_op(dims, base_comm)
+        super().__init__(dims=dims, dimsd=self.Op.dimsd, dtype=dtype, base_comm=base_comm)
 
     def _matvec(self, x: DistributedArray) -> StackedDistributedArray:
         return self.Op._matvec(x)
@@ -98,14 +97,14 @@ class MPIGradient(MPIStackedLinearOperator):
     def _rmatvec(self, x: StackedDistributedArray) -> DistributedArray:
         return self.Op._rmatvec(x)
 
-    def _calc_stack_op(self, ndims):
-        local_dims = local_split(tuple(self.dims), self.base_comm, Partition.SCATTER, axis=0)
+    def _calc_stack_op(self, dims: tuple, base_comm: MPI.Comm):
+        local_dims = local_split(dims, base_comm, Partition.SCATTER, axis=0)
         grad_ops = []
-        Op1 = MPIFirstDerivative(dims=self.dims, sampling=self.sampling[0],
+        Op1 = MPIFirstDerivative(dims=dims, sampling=self.sampling[0],
                                  kind=self.kind, edge=self.edge,
                                  dtype=self.dtype)
         grad_ops.append(Op1)
-        for iax in range(1, ndims):
+        for iax in range(1, len(dims)):
             diag = MPIBlockDiag([
                 FirstDerivative(
                     dims=local_dims,

--- a/pylops_mpi/basicoperators/HStack.py
+++ b/pylops_mpi/basicoperators/HStack.py
@@ -97,7 +97,7 @@ class MPIHStack(MPILinearOperator):
             raise ValueError("Operators have different number of rows")
         hops = [oper.H for oper in self.ops]
         self.HStack = MPIVStack(ops=hops, base_comm=base_comm, dtype=dtype).H
-        super().__init__(shape=self.HStack.shape, dtype=self.HStack.dtype, base_comm=base_comm)
+        super().__init__(Op=self.HStack, dtype=self.HStack.dtype, base_comm=base_comm)
 
     def _matvec(self, x: DistributedArray) -> DistributedArray:
         return self.HStack.matvec(x)

--- a/pylops_mpi/basicoperators/HStack.py
+++ b/pylops_mpi/basicoperators/HStack.py
@@ -97,7 +97,7 @@ class MPIHStack(MPILinearOperator):
             raise ValueError("Operators have different number of rows")
         hops = [oper.H for oper in self.ops]
         self.HStack = MPIVStack(ops=hops, base_comm=base_comm, dtype=dtype).H
-        super().__init__(Op=self.HStack, dtype=self.HStack.dtype, base_comm=base_comm)
+        super().__init__(dims=self.HStack.dims, dimsd=self.HStack.dimsd, dtype=self.HStack.dtype, base_comm=base_comm)
 
     def _matvec(self, x: DistributedArray) -> DistributedArray:
         return self.HStack.matvec(x)

--- a/pylops_mpi/basicoperators/Halo.py
+++ b/pylops_mpi/basicoperators/Halo.py
@@ -190,7 +190,7 @@ class MPIHalo(DistributedMixIn, MPILinearOperator):
         dimsd = (self._allreduce(
             comm,
             None,
-            np.prod(np.array(self.local_extent))
+            np.prod(self.local_extent)
         ), )
         super().__init__(dims=dims, dimsd=dimsd, dtype=np.dtype(dtype), base_comm=comm)
 

--- a/pylops_mpi/basicoperators/Halo.py
+++ b/pylops_mpi/basicoperators/Halo.py
@@ -187,11 +187,11 @@ class MPIHalo(DistributedMixIn, MPILinearOperator):
             int(np.prod(self.local_extent)),
         )
 
-        self.shape = (
+        shape = (
             int(np.sum(self._local_extent_sizes)),
             int(np.prod(self.global_dims)),
         )
-        super().__init__(shape=self.shape, dtype=np.dtype(dtype), base_comm=comm)
+        super().__init__(shape=shape, dtype=np.dtype(dtype), base_comm=comm)
 
     def _parse_halo(self, h: Union[int, tuple]) -> tuple:
         """Normalize halo input to a 2 * ndim tuple of per-side widths for each axis of the N-dimensional array.

--- a/pylops_mpi/basicoperators/Halo.py
+++ b/pylops_mpi/basicoperators/Halo.py
@@ -186,11 +186,11 @@ class MPIHalo(DistributedMixIn, MPILinearOperator):
             None,
             int(np.prod(self.local_extent)),
         )
-        dims = (self.global_dims,)
+        dims = self.global_dims
         dimsd = (self._allreduce(
             comm,
             None,
-            np.prod(self.local_extent)
+            np.prod(np.array(self.local_extent))
         ), )
         super().__init__(dims=dims, dimsd=dimsd, dtype=np.dtype(dtype), base_comm=comm)
 

--- a/pylops_mpi/basicoperators/Halo.py
+++ b/pylops_mpi/basicoperators/Halo.py
@@ -186,12 +186,13 @@ class MPIHalo(DistributedMixIn, MPILinearOperator):
             None,
             int(np.prod(self.local_extent)),
         )
-
-        shape = (
-            int(np.sum(self._local_extent_sizes)),
-            int(np.prod(self.global_dims)),
-        )
-        super().__init__(shape=shape, dtype=np.dtype(dtype), base_comm=comm)
+        dims = (self.global_dims,)
+        dimsd = (self._allreduce(
+            comm,
+            None,
+            np.prod(self.local_extent)
+        ), )
+        super().__init__(dims=dims, dimsd=dimsd, dtype=np.dtype(dtype), base_comm=comm)
 
     def _parse_halo(self, h: Union[int, tuple]) -> tuple:
         """Normalize halo input to a 2 * ndim tuple of per-side widths for each axis of the N-dimensional array.

--- a/pylops_mpi/basicoperators/Laplacian.py
+++ b/pylops_mpi/basicoperators/Laplacian.py
@@ -5,6 +5,7 @@ from mpi4py import MPI
 from pylops.utils.typing import DTypeLike, InputDimsLike
 from pylops.basicoperators import SecondDerivative
 from pylops.utils.backend import get_normalize_axis_index
+from pylops.utils._internal import _value_or_sized_to_tuple
 
 from pylops_mpi import DistributedArray, MPILinearOperator, Partition
 from pylops_mpi.DistributedArray import local_split
@@ -74,7 +75,7 @@ class MPILaplacian(MPILinearOperator):
                  kind: str = "centered",
                  base_comm: MPI.Comm = MPI.COMM_WORLD,
                  dtype: DTypeLike = np.float64):
-        self.dims = dims
+        dims = _value_or_sized_to_tuple(dims)
         axes = tuple(get_normalize_axis_index()(ax, len(dims)) for ax in axes)
         if not (len(axes) == len(weights) == len(sampling)):
             raise ValueError("axes, weights, and sampling have different size")
@@ -84,9 +85,8 @@ class MPILaplacian(MPILinearOperator):
         self.edge = edge
         self.kind = kind
         self.dtype = np.dtype(dtype)
-        self.base_comm = base_comm
-        self.Op = self._calc_l2op()
-        super().__init__(shape=self.Op.shape, dtype=self.dtype, base_comm=self.base_comm)
+        self.Op = self._calc_l2op(dims, base_comm)
+        super().__init__(dims=dims, dimsd=self.Op.dimsd, dtype=self.dtype, base_comm=base_comm)
 
     def _matvec(self, x: DistributedArray) -> DistributedArray:
         return self.Op @ x
@@ -94,10 +94,10 @@ class MPILaplacian(MPILinearOperator):
     def _rmatvec(self, x: DistributedArray) -> DistributedArray:
         return self.Op.H @ x
 
-    def _calc_l2op(self):
-        local_dims = local_split(tuple(self.dims), self.base_comm, Partition.SCATTER, axis=0)
+    def _calc_l2op(self, dims: tuple, base_comm: MPI.Comm):
+        local_dims = local_split(tuple(dims), base_comm, Partition.SCATTER, axis=0)
         if self.axes[0] == 0:
-            l2op = self.weights[0] * MPISecondDerivative(dims=self.dims,
+            l2op = self.weights[0] * MPISecondDerivative(dims=dims,
                                                          sampling=self.sampling[0],
                                                          kind=self.kind,
                                                          edge=self.edge,
@@ -111,7 +111,7 @@ class MPILaplacian(MPILinearOperator):
                                                                         dtype=self.dtype)])
         for ax, samp, weight in zip(self.axes[1:], self.sampling[1:], self.weights[1:]):
             if ax == 0:
-                l2op += weight * MPISecondDerivative(dims=self.dims,
+                l2op += weight * MPISecondDerivative(dims=dims,
                                                      sampling=samp,
                                                      kind=self.kind,
                                                      edge=self.edge,

--- a/pylops_mpi/basicoperators/MatrixMult.py
+++ b/pylops_mpi/basicoperators/MatrixMult.py
@@ -334,10 +334,9 @@ class _MPIBlockMatrixMult(DistributedMixIn, MPILinearOperator):
         self._rank_col_lens = self._allgather(self.base_comm, None, self._local_ncols)
         total_ncols = np.sum(self._rank_col_lens)
 
-        self.dims = (self.K, total_ncols)
-        self.dimsd = (self.N, total_ncols)
-        shape = (int(np.prod(self.dimsd)), int(np.prod(self.dims)))
-        super().__init__(shape=shape, dtype=np.dtype(dtype), base_comm=base_comm)
+        dims = (self.K, total_ncols)
+        dimsd = (self.N, total_ncols)
+        super().__init__(dims=dims, dimsd=dimsd, dtype=np.dtype(dtype), base_comm=base_comm)
 
     def _matvec(self, x: DistributedArray) -> DistributedArray:
         ncp = get_module(x.engine)
@@ -604,10 +603,9 @@ class _MPISummaMatrixMult(DistributedMixIn, MPILinearOperator):
         if saveAt:
             self.At = self.A.T.conj()
 
-        self.dims = (self.K, self.M)
-        self.dimsd = (self.N, self.M)
-        shape = (int(np.prod(self.dimsd)), int(np.prod(self.dims)))
-        super().__init__(shape=shape, dtype=np.dtype(dtype), base_comm=base_comm)
+        dims = (self.K, self.M)
+        dimsd = (self.N, self.M)
+        super().__init__(dims=dims, dimsd=dimsd, dtype=np.dtype(dtype), base_comm=base_comm)
 
     def _matvec(self, x: DistributedArray) -> DistributedArray:
         ncp = get_module(x.engine)

--- a/pylops_mpi/basicoperators/SecondDerivative.py
+++ b/pylops_mpi/basicoperators/SecondDerivative.py
@@ -80,9 +80,8 @@ class MPISecondDerivative(MPILinearOperator):
             base_comm: MPI.Comm = MPI.COMM_WORLD,
             dtype: DTypeLike = np.float64,
     ) -> None:
-        self.dims = _value_or_sized_to_tuple(dims)
-        shape = (int(np.prod(dims)),) * 2
-        super().__init__(shape=shape, dtype=np.dtype(dtype), base_comm=base_comm)
+        dims = _value_or_sized_to_tuple(dims)
+        super().__init__(dims=dims, dimsd=dims, dtype=np.dtype(dtype), base_comm=base_comm)
         self.sampling = sampling
         self.kind = kind
         self.edge = edge

--- a/pylops_mpi/basicoperators/VStack.py
+++ b/pylops_mpi/basicoperators/VStack.py
@@ -184,9 +184,10 @@ class MPIStackedVStack(MPIStackedLinearOperator):
         self.ops = ops
         if len(set(op.shape[1] for op in ops)) > 1:
             raise ValueError("Operators have different number of columns")
-        shape = (int(sum(op.shape[0] for op in ops)), ops[0].shape[1])
+        dims = (ops[0].shape[1], )
+        dimsd = (int(sum(op.shape[0] for op in ops)), )
         dtype = _get_dtype(self.ops) if dtype is None else np.dtype(dtype)
-        super().__init__(shape=shape, dtype=dtype, base_comm=base_comm)
+        super().__init__(dims=dims, dimsd=dimsd, dtype=dtype, base_comm=base_comm)
 
     def _matvec(self, x: DistributedArray) -> StackedDistributedArray:
         y1 = []

--- a/pylops_mpi/basicoperators/VStack.py
+++ b/pylops_mpi/basicoperators/VStack.py
@@ -113,9 +113,10 @@ class MPIVStack(DistributedMixIn, MPILinearOperator):
             raise ValueError("Operators have different number of columns")
         self.mops = int(mops[0])
         self.nnops = np.insert(np.cumsum(nops), 0, 0)
-        shape = (base_comm.allreduce(self.nops), self.mops)
+        dimsd = (base_comm.allreduce(self.nops), )
+        dims = (self.mops, )
         dtype = _get_dtype(self.ops) if dtype is None else np.dtype(dtype)
-        super().__init__(shape=shape, dtype=dtype, base_comm=base_comm)
+        super().__init__(dims=dims, dimsd=dimsd, dtype=dtype, base_comm=base_comm)
 
     def _matvec(self, x: DistributedArray) -> DistributedArray:
         ncp = get_module(x.engine)

--- a/pylops_mpi/signalprocessing/Fredholm1.py
+++ b/pylops_mpi/signalprocessing/Fredholm1.py
@@ -95,11 +95,9 @@ class MPIFredholm1(MPILinearOperator):
         self.islstart = np.insert(np.cumsum(self.nsls)[:-1], 0, 0)
         self.islend = np.cumsum(self.nsls)
         self.rank = base_comm.Get_rank()
-        self.dims = (nslstot, self.ny, self.nz)
-        self.dimsd = (nslstot, self.nx, self.nz)
-        shape = (np.prod(self.dimsd),
-                 np.prod(self.dims))
-        super().__init__(shape=shape, dtype=np.dtype(dtype), base_comm=base_comm)
+        dims = (nslstot, self.ny, self.nz)
+        dimsd = (nslstot, self.nx, self.nz)
+        super().__init__(dims=dims, dimsd=dimsd, dtype=np.dtype(dtype), base_comm=base_comm)
 
         self.G = G
         if saveGt:

--- a/pylops_mpi/signalprocessing/_baseffts.py
+++ b/pylops_mpi/signalprocessing/_baseffts.py
@@ -123,7 +123,7 @@ class _MPIBaseFFTND(MPILinearOperator):
         self.rdtype = get_real_dtype(dtype) if self.real else np.dtype(dtype)
         self.cdtype = get_complex_dtype(dtype)
         self.clinear = False if self.real or np.issubdtype(dtype, np.floating) else True
-        super().__init__(dtype=self.cdtype, shape=(int(np.prod(dimsd)), int(np.prod(dims))), base_comm=base_comm)
+        super().__init__(dtype=self.cdtype, dimsd=dimsd, dims=dims, base_comm=base_comm)
 
     def _matvec(self, x: DistributedArray) -> DistributedArray:
         msg = "_BaseFFT does not provide _matvec. It must be implemented separately."

--- a/tests/test_linearop.py
+++ b/tests/test_linearop.py
@@ -24,6 +24,7 @@ from pylops_mpi import (
     DistributedArray,
     MPILinearOperator,
     MPIBlockDiag,
+    MPIFirstDerivative,
     MPIVStack,
     Partition
 )
@@ -376,3 +377,38 @@ def test_adj_mpilinop(par):
         FullOp = VStack @ Fop
         y_np = FullOp.H @ x_global
         assert_allclose(y, y_np.flatten(), rtol=1e-9)
+
+
+@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
+def test_copy_dims_dimsd(par):
+    """Apply various overloaded operators (.H, -, +, *) and ensure that the
+    dims and dimsd properties are propagated
+    """
+    Dy = MPIFirstDerivative((par["ny"], par["nx"]))
+    Dx = MPIFirstDerivative((par["ny"], par["nx"]))
+    dims = (par["ny"], par["nx"])
+    dimsd = (par["ny"], par["nx"])
+
+    # negate
+    assert (-Dx).dims == dims
+    assert (-Dx).dimsd == dimsd
+    # multiply by scalar
+    assert (2 * Dx).dims == dims
+    assert (2 * Dx).dimsd == dimsd
+    assert (Dx * 2).dims == dims
+    assert (Dx * 2).dimsd == dimsd
+    # +
+    assert (Dx + Dy).dims == dims
+    assert (Dx + Dy).dimsd == dimsd
+    # -
+    assert (Dx - 2 * Dy).dims == dims
+    assert (Dx - 2 * Dy).dimsd == dimsd
+    # **
+    assert (Dx**3).dims == dims
+    assert (Dx**3).dimsd == dimsd
+    # Hermitian
+    assert Dx.H.dims == dimsd
+    assert Dx.H.dimsd == dims
+    # Transpose
+    assert Dx.T.dims == dimsd
+    assert Dx.T.dimsd == dims

--- a/tests/test_stackedlinearop.py
+++ b/tests/test_stackedlinearop.py
@@ -325,3 +325,39 @@ def test_product(par):
         Pop = StackedBDiag_1 * StackedBDiag_2
         assert_allclose(Pop_x_np, Pop @ x_global, rtol=1e-14)
         assert_allclose(Pop_y_np, Pop.H @ y_global, rtol=1e-14)
+
+
+@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
+def test_copy_dims_dimsd(par):
+    """Apply various overloaded operators (.H, -, +, *) and ensure that the
+    dims and dimsd properties are propagated
+    """
+    Dx = pylops_mpi.MPIFirstDerivative((par["ny"], par["nx"]))
+    Dy = pylops_mpi.MPIFirstDerivative((par["nx"], par["ny"]))
+    dims_stack = (2 * par["ny"] * par['nx'], )
+    dimsd_stack = (2 * par["ny"] * par['nx'],)
+    Stack = pylops_mpi.MPIStackedBlockDiag(ops=[Dx, Dy])
+
+    # negate
+    assert (-Stack).dims == dims_stack
+    assert (-Stack).dimsd == dimsd_stack
+    # multiply by scalar
+    assert (2 * Stack).dims == dims_stack
+    assert (2 * Stack).dimsd == dimsd_stack
+    assert (Stack * 2).dims == dims_stack
+    assert (Stack * 2).dimsd == dimsd_stack
+    # +
+    assert (Stack + Stack).dims == dims_stack
+    assert (Stack + Stack).dimsd == dimsd_stack
+    # -
+    assert (5 * Stack - 3 * Stack).dims == dims_stack
+    assert (5 * Stack - 3 * Stack).dimsd == dimsd_stack
+    # **
+    assert (Stack**3).dims == dims_stack
+    assert (Stack**3).dimsd == dimsd_stack
+    # Hermitian
+    assert Stack.H.dims == dimsd_stack
+    assert Stack.H.dimsd == dims_stack
+    # Transpose
+    assert Stack.T.dims == dimsd_stack
+    assert Stack.T.dimsd == dims_stack


### PR DESCRIPTION
- Introduce `dims` and `dimsd` as parameters in `MPILinearOperator` and `MPIStackedLinearOperator`.
- Add `dims` and `dimsd` to operators.