### PR TITLE
Feat: allow nested stacked arrays

### DIFF
--- a/examples/plot_stacked_array.py
+++ b/examples/plot_stacked_array.py
@@ -3,9 +3,9 @@ Stacked Array
 =============
 This example shows how to use the :py:class:`pylops_mpi.StackedDistributedArray`.
 This class provides a way to combine and act on multiple :py:class:`pylops_mpi.DistributedArray`
-within the same program. This is very useful in scenarios where an array can be logically
-divided in subarrays and each of them lends naturally to distribution across multiple processes in
-a parallel computing environment.
+and :py:class:`pylops_mpi.StackedDistributedArray` within the same program. This is very useful
+in scenarios where an array can be logically divided in subarrays and each of them lends naturally
+to distribution across multiple processes in a parallel computing environment.
 """
 
 from matplotlib import pyplot as plt
@@ -144,7 +144,7 @@ if rank == 0:
     print('StackedVStack xadj', xadj, xadj_arr, xadj_arr.shape)
 
 ###############################################################################
-# Finally, let's solve now an inverse problem using stacked arrays instead
+# Let's solve now an inverse problem using stacked arrays instead
 # of distributed arrays
 x0 = x.copy()
 x0[:] = 0.
@@ -153,3 +153,53 @@ xinv_array = xinv.asarray()
 
 if rank == 0:
     print('xinv_array', xinv_array)
+
+###############################################################################
+# Finally, let's move a step further and combine multiple a 
+# :py:class:`pylops_mpi.DistributedArray` with a 
+# :py:class:`pylops_mpi.StackedDistributedArray`, leading to a nested
+# :py:class:`pylops_mpi.StackedDistributedArray`
+
+subarr1_ = pylops_mpi.DistributedArray(global_shape=size * 10,
+                                       partition=pylops_mpi.Partition.SCATTER,
+                                       axis=0)
+subarr2_ = pylops_mpi.DistributedArray(global_shape=size * 4,
+                                       partition=pylops_mpi.Partition.SCATTER,
+                                       axis=0)
+subarr3_ = pylops_mpi.DistributedArray(global_shape=size * 2,
+                                       partition=pylops_mpi.Partition.SCATTER,
+                                       axis=0)
+
+# Filling the local arrays
+subarr1_[:], subarr2_[:], subarr3_[:] = 5, 6, 7
+arr12 = pylops_mpi.StackedDistributedArray([subarr1_, subarr2_])
+arr3 = pylops_mpi.StackedDistributedArray([arr12, subarr3_])
+if rank == 0:
+    print('Stacked array:', arr3)
+
+# Extract and print full array
+full_arr3 = arr3.asarray()
+if rank == 0:
+    print('Full array:', full_arr3)
+
+###############################################################################
+# Basic operations can still be applied on this nested Stacked Distributed
+# array
+
+# Negation
+neg_arr = -arr3
+full_neg_arr = neg_arr.asarray()
+if rank == 0:
+    print('Negated full array:', full_neg_arr)
+
+# Element-wise Addition
+sum_arr = arr3 + arr3
+full_sum_arr = sum_arr.asarray()
+if rank == 0:
+    print('Summed full array:', full_sum_arr)
+
+# Element-wise Subtraction
+sub_arr = arr3 - arr3
+full_sub_arr = sub_arr.asarray()
+if rank == 0:
+    print('Subtracted full array:', full_sub_arr)

--- a/pylops_mpi/DistributedArray.py
+++ b/pylops_mpi/DistributedArray.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from numbers import Integral
-from typing import Any, List, Optional, Tuple, Union, NewType
+from typing import Any, List, NewType, Optional, Self, Tuple, Union
 
 import numpy as np
 from mpi4py import MPI
@@ -985,8 +985,9 @@ class StackedDistributedArray:
         # Define global shape as sum as shapes
         self.global_shape = distarrays[0].global_shape
         for iarr in range(1, self.narrays):
-            self.global_shape = tuple([g1 + g2 for g1, g2 in \
-                zip(self.global_shape, distarrays[iarr].global_shape)])
+            self.global_shape = \
+                tuple([g1 + g2 for g1, g2 in
+                       zip(self.global_shape, distarrays[iarr].global_shape)])
 
     @property
     def engine(self):
@@ -1016,7 +1017,7 @@ class StackedDistributedArray:
             # plain DistributedArray assigned from an array-like / scalar
             target[:] = value
 
-    def asarray(self):
+    def asarray(self) -> NDArray:
         """Global view of the array
 
         Gather all the distributed arrays
@@ -1030,7 +1031,7 @@ class StackedDistributedArray:
         ncp = get_module(self.engine)
         return ncp.hstack([distarr.asarray().ravel() for distarr in self.distarrays])
 
-    def _check_stacked_size(self, stacked_array):
+    def _check_stacked_size(self, stacked_array: Self) -> None:
         """Check that arrays have consistent size
 
         """
@@ -1069,7 +1070,7 @@ class StackedDistributedArray:
     def __rmul__(self, x):
         return self.multiply(x)
 
-    def add(self, stacked_array):
+    def add(self, stacked_array: Self) -> Self:
         """Stacked Distributed Addition of arrays
         """
         self._check_stacked_size(stacked_array)
@@ -1081,7 +1082,7 @@ class StackedDistributedArray:
                 SumArray[iarr][:] = (self[iarr] + stacked_array[iarr])[:]
         return SumArray
 
-    def iadd(self, stacked_array):
+    def iadd(self, stacked_array: Self) -> Self:
         """Stacked Distributed In-Place Addition of arrays
         """
         self._check_stacked_size(stacked_array)
@@ -1092,7 +1093,7 @@ class StackedDistributedArray:
                 self[iarr][:] = (self[iarr] + stacked_array[iarr])[:]
         return self
 
-    def multiply(self, stacked_array):
+    def multiply(self, stacked_array: float | int | Self) -> Self:
         """Stacked Distributed Multiplication of arrays
         """
         if isinstance(stacked_array, StackedDistributedArray):
@@ -1115,7 +1116,7 @@ class StackedDistributedArray:
                     ProductArray[iarr][:] = (self[iarr] * stacked_array)[:]
         return ProductArray
 
-    def dot(self, stacked_array, vdot: bool = False):
+    def dot(self, stacked_array: Self, vdot: bool = False) -> Self:
         """
         Compute the distributed dot product between this array and another
         distributed array.
@@ -1141,7 +1142,7 @@ class StackedDistributedArray:
             dotprod += self[iarr].dot(stacked_array[iarr], vdot=vdot)
         return dotprod
 
-    def norm(self, ord: Optional[int] = None):
+    def norm(self, ord: Optional[int] = None) -> bool | float:
         """numpy.linalg.norm method on stacked Distributed arrays
 
         Parameters
@@ -1167,19 +1168,19 @@ class StackedDistributedArray:
             norm = ncp.power(ncp.sum(ncp.power(norms, ord)), 1. / ord)
         return norm
 
-    def conj(self):
+    def conj(self) -> Self:
         """Distributed conj() method
         """
         ConjArray = StackedDistributedArray([distarray.conj() for distarray in self.distarrays])
         return ConjArray
 
-    def copy(self):
+    def copy(self) -> Self:
         """Creates a copy of the DistributedArray
         """
         arr = StackedDistributedArray([distarray.copy() for distarray in self.distarrays])
         return arr
 
-    def zeros_like(self):
+    def zeros_like(self) -> Self:
         """Creates a zero like StackedDistributedArray
         """
         dists = []
@@ -1193,7 +1194,7 @@ class StackedDistributedArray:
             dists.append(dist)
         return StackedDistributedArray(distarrays=dists)
 
-    def empty_like(self):
+    def empty_like(self) -> Self:
         """Creates an empty like StackedDistributedArray with uninitialized values
         """
         dists = []
@@ -1206,6 +1207,6 @@ class StackedDistributedArray:
             dists.append(dist)
         return StackedDistributedArray(distarrays=dists)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         repr_dist = "\n".join([distarray.__repr__() for distarray in self.distarrays])
         return f"<StackedDistributedArray with {self.narrays} distributed arrays: \n" + repr_dist

--- a/pylops_mpi/DistributedArray.py
+++ b/pylops_mpi/DistributedArray.py
@@ -273,11 +273,12 @@ class DistributedArray(DistributedMixIn):
 
     @property
     def engine(self):
-        """Engine of the Distributed array
+        """Engine of the Distributed Array
 
         Returns
         -------
         engine : :obj:`str`
+            Engine
         """
         return self._engine
 
@@ -963,8 +964,11 @@ class StackedDistributedArray:
     r"""Stacked DistributedArrays
 
     Stack DistributedArray objects and power them with basic mathematical operations.
-    This class allows one to work with a series of distributed arrays to avoid having to create
-    a single distributed array with some special internal sorting.
+    This class allows one to work with a series of distributed arrays to avoid
+    having to create a single distributed array with some special internal sorting.
+
+    .. note:: All :class:`pylops_mpi.DistributedArray` objects passed to
+        ``distarrays`` must share the same engine (``numpy`` or ``cupy``).
 
     Parameters
     ----------
@@ -973,6 +977,11 @@ class StackedDistributedArray:
     base_comm : :obj:`mpi4py.MPI.Comm`, optional
         Base MPI Communicator.
         Defaults to ``mpi4py.MPI.COMM_WORLD``.
+
+    Raises
+    ------
+    ValueError
+        Stacked distributed arrays have different engine
     """
 
     def __init__(self, distarrays: List, base_comm: MPI.Comm = MPI.COMM_WORLD):
@@ -982,24 +991,21 @@ class StackedDistributedArray:
         self.rank = base_comm.Get_rank()
         self.size = base_comm.Get_size()
 
+        # Ensure all stacked arrays share the same engine
+        engines = [distarr.engine for distarr in distarrays]
+        if any(engine != engines[0] for engine in engines[1:]):
+            raise ValueError(f"Stacked arrays have mismatching engines: {engines}")
+
         # Define global shape as sum as shapes
-        self.global_shape = distarrays[0].global_shape
+        self._global_shape = distarrays[0].global_shape
         for iarr in range(1, self.narrays):
-            self.global_shape = \
+            self._global_shape = \
                 tuple([g1 + g2 for g1, g2 in
-                       zip(self.global_shape, distarrays[iarr].global_shape)])
+                       zip(self._global_shape, distarrays[iarr].global_shape)])
 
-    @property
-    def engine(self):
-        """Engine
-
-        Find engine by inspecting the first :class:`pylops_mpi.DistributedArray`
-        among ``distarrays`` (some may be nested
-        :class:`pylops_mpi.StackedDistributedArray`, which expose this same
-        property).
-        """
-        return next(distarr.engine for distarr in self.distarrays
-                    if isinstance(distarr, (DistributedArray, StackedDistributedArray)))
+    def __repr__(self) -> str:
+        repr_dist = "\n".join([distarray.__repr__() for distarray in self.distarrays])
+        return f"<StackedDistributedArray with {self.narrays} distributed arrays: \n" + repr_dist
 
     def __getitem__(self, index):
         return self.distarrays[index]
@@ -1017,15 +1023,43 @@ class StackedDistributedArray:
             # plain DistributedArray assigned from an array-like / scalar
             target[:] = value
 
+    @property
+    def global_shape(self):
+        """Global Shape of the stacked array
+
+        Returns
+        -------
+        global_shape : :obj:`tuple`
+        """
+        return self._global_shape
+
+    @property
+    def engine(self):
+        """Engine of the Stacked Distributed Array
+
+        All stacked arrays share the same engine (enforced at creation time).
+        A nested :class:`pylops_mpi.StackedDistributedArray` exposes this same
+        property, so this resolves recursively until it reaches a
+        :class:`pylops_mpi.DistributedArray`.
+
+        Returns
+        -------
+        engine : :obj:`str`
+            Engine
+
+        """
+        return self.distarrays[0].engine
+
     def asarray(self) -> NDArray:
         """Global view of the array
 
-        Gather all the distributed arrays
+        Gather all the distributed arrays and return
+        a flattened version
 
         Returns
         -------
         final_array : :obj:`numpy.ndarray`
-            Global Array gathered at all ranks
+            Global Array gathered at all ranks and flattened
 
         """
         ncp = get_module(self.engine)
@@ -1206,7 +1240,3 @@ class StackedDistributedArray:
                                     engine=distarray.engine, dtype=distarray.dtype)
             dists.append(dist)
         return StackedDistributedArray(distarrays=dists)
-
-    def __repr__(self) -> str:
-        repr_dist = "\n".join([distarray.__repr__() for distarray in self.distarrays])
-        return f"<StackedDistributedArray with {self.narrays} distributed arrays: \n" + repr_dist

--- a/pylops_mpi/DistributedArray.py
+++ b/pylops_mpi/DistributedArray.py
@@ -982,11 +982,39 @@ class StackedDistributedArray:
         self.rank = base_comm.Get_rank()
         self.size = base_comm.Get_size()
 
+        # Define global shape as sum as shapes
+        self.global_shape = distarrays[0].global_shape
+        for iarr in range(1, self.narrays):
+            self.global_shape = tuple([g1 + g2 for g1, g2 in \
+                zip(self.global_shape, distarrays[iarr].global_shape)])
+
+    @property
+    def engine(self):
+        """Engine
+
+        Find engine by inspecting the first :class:`pylops_mpi.DistributedArray`
+        among ``distarrays`` (some may be nested
+        :class:`pylops_mpi.StackedDistributedArray`, which expose this same
+        property).
+        """
+        return next(distarr.engine for distarr in self.distarrays
+                    if isinstance(distarr, (DistributedArray, StackedDistributedArray)))
+
     def __getitem__(self, index):
         return self.distarrays[index]
 
     def __setitem__(self, index, value):
-        self.distarrays[index][:] = value
+        target = self.distarrays[index]
+        if isinstance(target, StackedDistributedArray):
+            # nested StackedDistributedArray: assign each sub-array in turn
+            for iarr in range(target.narrays):
+                target[iarr] = value[iarr]
+        elif isinstance(value, DistributedArray):
+            # plain DistributedArray: assign the local array
+            target[:] = value[:]
+        else:
+            # plain DistributedArray assigned from an array-like / scalar
+            target[:] = value
 
     def asarray(self):
         """Global view of the array
@@ -999,7 +1027,7 @@ class StackedDistributedArray:
             Global Array gathered at all ranks
 
         """
-        ncp = get_module(self.distarrays[0].engine)
+        ncp = get_module(self.engine)
         return ncp.hstack([distarr.asarray().ravel() for distarr in self.distarrays])
 
     def _check_stacked_size(self, stacked_array):
@@ -1017,7 +1045,10 @@ class StackedDistributedArray:
     def __neg__(self):
         arr = self.copy()
         for iarr in range(self.narrays):
-            arr[iarr][:] = -arr[iarr][:]
+            if isinstance(arr[iarr], StackedDistributedArray):
+                arr[iarr] = -arr[iarr]
+            else:
+                arr[iarr][:] = -arr[iarr][:]
         return arr
 
     def __add__(self, x):
@@ -1044,7 +1075,10 @@ class StackedDistributedArray:
         self._check_stacked_size(stacked_array)
         SumArray = self.copy()
         for iarr in range(self.narrays):
-            SumArray[iarr][:] = (self[iarr] + stacked_array[iarr])[:]
+            if isinstance(stacked_array[iarr], StackedDistributedArray):
+                SumArray[iarr] = (self[iarr] + stacked_array[iarr])
+            else:
+                SumArray[iarr][:] = (self[iarr] + stacked_array[iarr])[:]
         return SumArray
 
     def iadd(self, stacked_array):
@@ -1052,7 +1086,10 @@ class StackedDistributedArray:
         """
         self._check_stacked_size(stacked_array)
         for iarr in range(self.narrays):
-            self[iarr][:] = (self[iarr] + stacked_array[iarr])[:]
+            if isinstance(self[iarr], StackedDistributedArray):
+                self[iarr] = (self[iarr] + stacked_array[iarr])
+            else:
+                self[iarr][:] = (self[iarr] + stacked_array[iarr])[:]
         return self
 
     def multiply(self, stacked_array):
@@ -1063,13 +1100,19 @@ class StackedDistributedArray:
         ProductArray = self.copy()
 
         if isinstance(stacked_array, StackedDistributedArray):
-            # multiply two DistributedArray
+            # multiply two StackedDistributedArray
             for iarr in range(self.narrays):
-                ProductArray[iarr][:] = (self[iarr] * stacked_array[iarr])[:]
+                if isinstance(self[iarr], StackedDistributedArray):
+                    ProductArray[iarr] = (self[iarr] * stacked_array[iarr])
+                else:
+                    ProductArray[iarr][:] = (self[iarr] * stacked_array[iarr])[:]
         else:
             # multiply with scalar
             for iarr in range(self.narrays):
-                ProductArray[iarr][:] = (self[iarr] * stacked_array)[:]
+                if isinstance(self[iarr], StackedDistributedArray):
+                    ProductArray[iarr] = (self[iarr] * stacked_array)
+                else:
+                    ProductArray[iarr][:] = (self[iarr] * stacked_array)[:]
         return ProductArray
 
     def dot(self, stacked_array, vdot: bool = False):
@@ -1106,8 +1149,8 @@ class StackedDistributedArray:
         ord : :obj:`int`, optional
             Order of the norm.
         """
-        ncp = get_module(self.distarrays[0].engine)
-        norms = ncp.array([distarray.norm(ord) for distarray in self.distarrays])
+        ncp = get_module(self.engine)
+        norms = ncp.hstack([distarray.norm(ord) for distarray in self.distarrays])
         ord = 2 if ord is None else ord
         if ord in ['fro', 'nuc']:
             raise ValueError(f"norm-{ord} not possible for vectors")
@@ -1135,6 +1178,20 @@ class StackedDistributedArray:
         """
         arr = StackedDistributedArray([distarray.copy() for distarray in self.distarrays])
         return arr
+
+    def zeros_like(self):
+        """Creates a zero like StackedDistributedArray
+        """
+        dists = []
+        for iarr in range(self.narrays):
+            distarray = self.distarrays[iarr]
+            dist = DistributedArray(global_shape=distarray.global_shape, base_comm=distarray.base_comm,
+                                    base_comm_nccl=distarray.base_comm_nccl, partition=distarray.partition,
+                                    axis=distarray.axis, local_shapes=distarray.local_shapes, mask=distarray.mask,
+                                    engine=distarray.engine, dtype=distarray.dtype)
+            dist[:] = 0.
+            dists.append(dist)
+        return StackedDistributedArray(distarrays=dists)
 
     def empty_like(self):
         """Creates an empty like StackedDistributedArray with uninitialized values

--- a/tests/test_distributedarray.py
+++ b/tests/test_distributedarray.py
@@ -343,7 +343,7 @@ def test_distributed_maskednorm(par):
     if par['axis'] != 0:
         x = np.swapaxes(x, 0, par['axis'])
     arr = DistributedArray.to_dist(x=x, mask=mask, axis=par['axis'])
-    # TODO (tharitt): Fail with CuPy + MPI
+
     assert_allclose(
         arr.norm(ord=1, axis=par['norm_axis']),
         np.linalg.norm(par['x'], ord=1, axis=par['norm_axis']) / (nsub if par['axis'] == par['norm_axis'] else 1),

--- a/tests/test_stackedarray.py
+++ b/tests/test_stackedarray.py
@@ -40,11 +40,11 @@ par2j = {'global_shape': (501, 500),
          'partition': Partition.BROADCAST, 'dtype': np.complex128,
          'axis': 0}
 
-par3 = {'global_shape': (200, 201, 101),
+par3 = {'global_shape': (100, 101, 51),
         'partition': Partition.SCATTER,
         'dtype': np.float64, 'axis': 1}
 
-par3j = {'global_shape': (200, 201, 101),
+par3j = {'global_shape': (100, 101, 51),
          'partition': Partition.SCATTER,
          'dtype': np.complex128, 'axis': 2}
 

--- a/tests/test_stackedarray.py
+++ b/tests/test_stackedarray.py
@@ -86,7 +86,8 @@ def test_creation(par):
 @pytest.mark.parametrize("par", [(par1), (par1j), (par2),
                                  (par2j), (par3), (par3j)])
 def test_stacked_math(par):
-    """Test the Element-Wise Addition, Subtraction and Multiplication, Dot-product, Norm"""
+    """Test Element-Wise Addition, Subtraction and Multiplication, Dot-product, Norm
+    for stacked distributed arrays"""
     distributed_array0 = DistributedArray(global_shape=par['global_shape'],
                                           partition=par['partition'],
                                           dtype=par['dtype'], axis=par['axis'],
@@ -100,6 +101,117 @@ def test_stacked_math(par):
 
     stacked_array1 = StackedDistributedArray([distributed_array0, distributed_array1])
     stacked_array2 = StackedDistributedArray([distributed_array1, distributed_array0])
+
+    # Addition
+    sum_array = stacked_array1 + stacked_array2
+    assert isinstance(sum_array, StackedDistributedArray)
+    assert_allclose(sum_array.asarray(), np.add(stacked_array1.asarray(),
+                                                stacked_array2.asarray()),
+                    rtol=1e-14)
+    # Subtraction
+    sub_array = stacked_array1 - stacked_array2
+    assert isinstance(sub_array, StackedDistributedArray)
+    assert_allclose(sub_array.asarray(), np.subtract(stacked_array1.asarray(),
+                                                     stacked_array2.asarray()),
+                    rtol=1e-14)
+    # Multiplication
+    mult_array = stacked_array1 * stacked_array2
+    assert isinstance(mult_array, StackedDistributedArray)
+    assert_allclose(mult_array.asarray(), np.multiply(stacked_array1.asarray(),
+                                                      stacked_array2.asarray()),
+                    rtol=1e-14)
+    # Dot-product
+    dot_prod = stacked_array1.dot(stacked_array2)
+    assert_allclose(dot_prod, np.dot(stacked_array1.asarray().flatten(),
+                                     stacked_array2.asarray().flatten()),
+                    rtol=1e-14)
+    # Norm
+    l0norm = stacked_array1.norm(0)
+    l1norm = stacked_array1.norm(1)
+    l2norm = stacked_array1.norm(2)
+
+    # TODO (tharitt): FAIL with CuPy + MPI for inf norm - see test_distributedarray.py
+    # test_distributed_nrom(par) as well
+#     linfnorm = stacked_array1.norm(np.inf)
+    assert_allclose(l0norm, np.linalg.norm(stacked_array1.asarray().flatten(), 0),
+                    rtol=1e-14)
+    assert_allclose(l1norm, np.linalg.norm(stacked_array1.asarray().flatten(), 1),
+                    rtol=1e-14)
+    assert_allclose(l2norm, np.linalg.norm(stacked_array1.asarray(), 2),
+                    rtol=1e-10)  # needed to raise it due to how partial norms are combined (with power applied)
+    # TODO (tharitt): FAIL at inf norm - see above
+#     assert_allclose(linfnorm, np.linalg.norm(stacked_array1.asarray().flatten(), np.inf),
+#                     rtol=1e-14)
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2),
+                                 (par2j), (par3), (par3j)])
+def test_creation_nested(par):
+    """Test creation of nested stacked distributed arrays"""
+    # Create stacked array
+    distributed_array0 = DistributedArray(global_shape=par['global_shape'],
+                                          partition=par['partition'],
+                                          dtype=par['dtype'], axis=par['axis'],
+                                          engine=backend)
+    distributed_array1 = DistributedArray(global_shape=par['global_shape'],
+                                          partition=par['partition'],
+                                          dtype=par['dtype'], axis=par['axis'],
+                                          engine=backend)
+    distributed_array2 = DistributedArray(global_shape=par['global_shape'],
+                                          partition=par['partition'],
+                                          dtype=par['dtype'], axis=par['axis'],
+                                          engine=backend)
+    distributed_array0[:] = 0
+    distributed_array1[:] = 1
+    distributed_array2[:] = 2
+
+    stacked_arrays_01 = StackedDistributedArray([distributed_array0, distributed_array1])
+    stacked_arrays = StackedDistributedArray([stacked_arrays_01, distributed_array2])
+    assert isinstance(stacked_arrays, StackedDistributedArray)
+    assert_allclose(stacked_arrays[0][0].local_array,
+                    np.zeros(shape=distributed_array0.local_shape,
+                             dtype=par['dtype']), rtol=1e-14)
+    assert_allclose(stacked_arrays[0][1].local_array,
+                    np.ones(shape=distributed_array0.local_shape,
+                             dtype=par['dtype']), rtol=1e-14)
+    assert_allclose(stacked_arrays[1].local_array,
+                    2 * np.ones(shape=distributed_array1.local_shape,
+                                dtype=par['dtype']), rtol=1e-14)
+
+    # Modify array in place
+    distributed_array0[:] = 2
+    assert_allclose(stacked_arrays[0][0].local_array,
+                    2 * np.ones(shape=distributed_array0.local_shape,
+                                dtype=par['dtype']), rtol=1e-14)
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2),
+                                 (par2j), (par3), (par3j)])
+def test_stacked_nested_math(par):
+    """Test Element-Wise Addition, Subtraction and Multiplication, Dot-product, Norm
+    for nested stacked distributed arrays"""
+    distributed_array0 = DistributedArray(global_shape=par['global_shape'],
+                                          partition=par['partition'],
+                                          dtype=par['dtype'], axis=par['axis'],
+                                          engine=backend)
+    distributed_array1 = DistributedArray(global_shape=par['global_shape'],
+                                          partition=par['partition'],
+                                          dtype=par['dtype'], axis=par['axis'],
+                                          engine=backend)
+    distributed_array2 = DistributedArray(global_shape=par['global_shape'],
+                                          partition=par['partition'],
+                                          dtype=par['dtype'], axis=par['axis'],
+                                          engine=backend)
+    distributed_array0[:] = 0
+    distributed_array1[:] = np.arange(npp.prod(distributed_array1.local_shape)).reshape(distributed_array1.local_shape)
+    distributed_array2[:] = np.ones(npp.prod(distributed_array2.local_shape)).reshape(distributed_array1.local_shape)
+
+    stacked_array_01 = StackedDistributedArray([distributed_array0, distributed_array1])
+    stacked_array_12 = StackedDistributedArray([distributed_array1, distributed_array2])
+    stacked_array1 = StackedDistributedArray([stacked_array_01, distributed_array2])
+    stacked_array2 = StackedDistributedArray([stacked_array_12, distributed_array0])
 
     # Addition
     sum_array = stacked_array1 + stacked_array2

--- a/tests/test_stackedarray.py
+++ b/tests/test_stackedarray.py
@@ -49,6 +49,31 @@ par3j = {'global_shape': (200, 201, 101),
          'dtype': np.complex128, 'axis': 2}
 
 
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1),])
+def test_wrong_engine(par):
+    """Test that an error is raised if a stacked distributed array
+    is created from distributed arrays with different engine"""
+    # Create stacked array
+    distributed_array0 = DistributedArray(global_shape=par['global_shape'],
+                                          partition=par['partition'],
+                                          dtype=par['dtype'], axis=par['axis'],
+                                          engine=backend)
+    distributed_array1 = DistributedArray(global_shape=par['global_shape'],
+                                          partition=par['partition'],
+                                          dtype=par['dtype'], axis=par['axis'],
+                                          engine=backend)
+
+    # Force engine (done this way as passing it during creation would
+    # raise an error if not numpy/cupy and cupy cannot be chosen for 
+    # CPU tests)
+    distributed_array0._engine = "foo"
+    
+    with pytest.raises(ValueError, match="Stacked arrays have "):
+        _ = StackedDistributedArray([distributed_array0, distributed_array1])
+
+
 @pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize("par", [(par1), (par1j), (par2),
                                  (par2j), (par3), (par3j)])
@@ -68,12 +93,21 @@ def test_creation(par):
 
     stacked_arrays = StackedDistributedArray([distributed_array0, distributed_array1])
     assert isinstance(stacked_arrays, StackedDistributedArray)
+    assert stacked_arrays.global_shape == tuple(gs * 2 for gs in par['global_shape'])
     assert_allclose(stacked_arrays[0].local_array,
                     np.zeros(shape=distributed_array0.local_shape,
                              dtype=par['dtype']), rtol=1e-14)
     assert_allclose(stacked_arrays[1].local_array,
                     np.ones(shape=distributed_array1.local_shape,
                             dtype=par['dtype']), rtol=1e-14)
+
+    # Asarray
+    stacked_arrays_local = stacked_arrays.asarray()
+    stacked_arrays_local_bench = np.hstack([
+        np.zeros(shape=distributed_array0.global_shape, dtype=par['dtype']).ravel(),
+        np.ones(shape=distributed_array1.global_shape, dtype=par['dtype']).ravel(),
+        ])
+    assert_allclose(stacked_arrays_local, stacked_arrays_local_bench, rtol=1e-14)
 
     # Modify array in place
     distributed_array0[:] = 2
@@ -145,10 +179,10 @@ def test_stacked_math(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par1j), (par2),
-                                 (par2j), (par3), (par3j)])
-def test_creation_nested(par):
-    """Test creation of nested stacked distributed arrays"""
+@pytest.mark.parametrize("par", [(par1),])
+def test_wrong_engine_nested(par):
+    """Test that an error is raised if a nested stacked distributed array
+    is created from distributed arrays with different engine"""
     # Create stacked array
     distributed_array0 = DistributedArray(global_shape=par['global_shape'],
                                           partition=par['partition'],
@@ -162,6 +196,35 @@ def test_creation_nested(par):
                                           partition=par['partition'],
                                           dtype=par['dtype'], axis=par['axis'],
                                           engine=backend)
+
+    # Force engine (done this way as passing it during creation would
+    # raise an error if not numpy/cupy and cupy cannot be chosen for 
+    # CPU tests)
+    distributed_array2._engine = "foo"
+    stacked_arrays_01 = StackedDistributedArray([distributed_array0, distributed_array1])
+    
+    with pytest.raises(ValueError, match="Stacked arrays have "):
+        _ = StackedDistributedArray([stacked_arrays_01, distributed_array2])
+    
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2),
+                                 (par2j), (par3), (par3j)])
+def test_creation_nested(par):
+    """Test creation of nested stacked distributed arrays"""
+    # Create stacked array
+    distributed_array0 = DistributedArray(global_shape=par['global_shape'],
+                                          partition=par['partition'],
+                                          dtype=par['dtype'], axis=par['axis'],
+                                          engine=backend)
+    distributed_array1 = DistributedArray(global_shape=par['global_shape'],
+                                          partition=par['partition'],
+                                          dtype=par['dtype'], axis=par['axis'],
+                                          engine=backend)
+    distributed_array2 = DistributedArray(global_shape=[gs * 2 for gs in par['global_shape']],
+                                          partition=par['partition'],
+                                          dtype=par['dtype'], axis=par['axis'],
+                                          engine=backend)
     distributed_array0[:] = 0
     distributed_array1[:] = 1
     distributed_array2[:] = 2
@@ -169,20 +232,34 @@ def test_creation_nested(par):
     stacked_arrays_01 = StackedDistributedArray([distributed_array0, distributed_array1])
     stacked_arrays = StackedDistributedArray([stacked_arrays_01, distributed_array2])
     assert isinstance(stacked_arrays, StackedDistributedArray)
+    assert stacked_arrays.global_shape == tuple(gs * 4 for gs in par['global_shape'])
     assert_allclose(stacked_arrays[0][0].local_array,
                     np.zeros(shape=distributed_array0.local_shape,
                              dtype=par['dtype']), rtol=1e-14)
     assert_allclose(stacked_arrays[0][1].local_array,
-                    np.ones(shape=distributed_array0.local_shape,
+                    np.ones(shape=distributed_array1.local_shape,
                              dtype=par['dtype']), rtol=1e-14)
     assert_allclose(stacked_arrays[1].local_array,
-                    2 * np.ones(shape=distributed_array1.local_shape,
+                    2 * np.ones(shape=distributed_array2.local_shape,
                                 dtype=par['dtype']), rtol=1e-14)
 
+    # Asarray
+    stacked_arrays_local = stacked_arrays.asarray()
+    stacked_arrays_local_bench = np.hstack([
+        np.zeros(shape=distributed_array0.global_shape, dtype=par['dtype']).ravel(),
+        np.ones(shape=distributed_array1.global_shape, dtype=par['dtype']).ravel(),
+        2 * np.ones(shape=distributed_array2.global_shape, dtype=par['dtype']).ravel(),
+        ])
+    assert_allclose(stacked_arrays_local, stacked_arrays_local_bench, rtol=1e-14)
+    
     # Modify array in place
     distributed_array0[:] = 2
     assert_allclose(stacked_arrays[0][0].local_array,
                     2 * np.ones(shape=distributed_array0.local_shape,
+                                dtype=par['dtype']), rtol=1e-14)
+    distributed_array2[:] = 4
+    assert_allclose(stacked_arrays[1].local_array,
+                    4 * np.ones(shape=distributed_array2.local_shape,
                                 dtype=par['dtype']), rtol=1e-14)
 
 

--- a/tests/test_stackedarray.py
+++ b/tests/test_stackedarray.py
@@ -49,7 +49,6 @@ par3j = {'global_shape': (200, 201, 101),
          'dtype': np.complex128, 'axis': 2}
 
 
-
 @pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize("par", [(par1),])
 def test_wrong_engine(par):
@@ -317,16 +316,13 @@ def test_stacked_nested_math(par):
     l0norm = stacked_array1.norm(0)
     l1norm = stacked_array1.norm(1)
     l2norm = stacked_array1.norm(2)
+    linfnorm = stacked_array1.norm(np.inf)
 
-    # TODO (tharitt): FAIL with CuPy + MPI for inf norm - see test_distributedarray.py
-    # test_distributed_nrom(par) as well
-#     linfnorm = stacked_array1.norm(np.inf)
     assert_allclose(l0norm, np.linalg.norm(stacked_array1.asarray().flatten(), 0),
                     rtol=1e-14)
     assert_allclose(l1norm, np.linalg.norm(stacked_array1.asarray().flatten(), 1),
                     rtol=1e-14)
     assert_allclose(l2norm, np.linalg.norm(stacked_array1.asarray(), 2),
                     rtol=1e-10)  # needed to raise it due to how partial norms are combined (with power applied)
-    # TODO (tharitt): FAIL at inf norm - see above
-#     assert_allclose(linfnorm, np.linalg.norm(stacked_array1.asarray().flatten(), np.inf),
-#                     rtol=1e-14)
+    assert_allclose(linfnorm, np.linalg.norm(stacked_array1.asarray().flatten(), np.inf),
+                    rtol=1e-14)

--- a/tests_nccl/test_stackedarray_nccl.py
+++ b/tests_nccl/test_stackedarray_nccl.py
@@ -59,12 +59,21 @@ def test_creation_nccl(par):
 
     stacked_arrays = StackedDistributedArray([distributed_array0, distributed_array1])
     assert isinstance(stacked_arrays, StackedDistributedArray)
+    assert stacked_arrays.global_shape == tuple(gs * 2 for gs in par['global_shape'])
     assert_allclose(stacked_arrays[0].local_array.get(),
                     np.zeros(shape=distributed_array0.local_shape,
                              dtype=par['dtype']), rtol=1e-14)
     assert_allclose(stacked_arrays[1].local_array.get(),
                     np.ones(shape=distributed_array1.local_shape,
                             dtype=par['dtype']), rtol=1e-14)
+
+    # Asarray
+    stacked_arrays_local = stacked_arrays.asarray().get()
+    stacked_arrays_local_bench = np.hstack([
+        np.zeros(shape=distributed_array0.global_shape, dtype=par['dtype']).ravel(),
+        np.ones(shape=distributed_array1.global_shape, dtype=par['dtype']).ravel(),
+        ])
+    assert_allclose(stacked_arrays_local, stacked_arrays_local_bench, rtol=1e-14)
 
     # Modify array in place
     distributed_array0[:] = 2
@@ -125,5 +134,127 @@ def test_stacked_math_nccl(par):
                     rtol=1e-14)
     assert_allclose(l2norm.get(), np.linalg.norm(stacked_array1.asarray().get(), 2),
                     rtol=1e-10)  # needed to raise it due to how partial norms are combined (with power applied)
+    assert_allclose(linfnorm.get(), np.linalg.norm(stacked_array1.asarray().flatten().get(), np.inf),
+                    rtol=1e-14)
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2),
+                                 (par2j), (par3), (par3j)])
+def test_creation_nested(par):
+    """Test creation of nested stacked distributed arrays"""
+    # Create stacked array
+    distributed_array0 = DistributedArray(global_shape=par['global_shape'],
+                                          partition=par['partition'],
+                                          dtype=par['dtype'], axis=par['axis'],
+                                          engine="cupy")
+    distributed_array1 = DistributedArray(global_shape=par['global_shape'],
+                                          partition=par['partition'],
+                                          dtype=par['dtype'], axis=par['axis'],
+                                          engine="cupy")
+    distributed_array2 = DistributedArray(global_shape=[gs * 2 for gs in par['global_shape']],
+                                          partition=par['partition'],
+                                          dtype=par['dtype'], axis=par['axis'],
+                                          engine="cupy")
+    distributed_array0[:] = 0
+    distributed_array1[:] = 1
+    distributed_array2[:] = 2
+
+    stacked_arrays_01 = StackedDistributedArray([distributed_array0, distributed_array1])
+    stacked_arrays = StackedDistributedArray([stacked_arrays_01, distributed_array2])
+    assert isinstance(stacked_arrays, StackedDistributedArray)
+    assert stacked_arrays.global_shape == tuple(gs * 4 for gs in par['global_shape'])
+    assert_allclose(stacked_arrays[0][0].local_array.get(),
+                    np.zeros(shape=distributed_array0.local_shape,
+                             dtype=par['dtype']), rtol=1e-14)
+    assert_allclose(stacked_arrays[0][1].local_array.get(),
+                    np.ones(shape=distributed_array1.local_shape,
+                             dtype=par['dtype']), rtol=1e-14)
+    assert_allclose(stacked_arrays[1].local_array.get(),
+                    2 * np.ones(shape=distributed_array2.local_shape,
+                                dtype=par['dtype']), rtol=1e-14)
+
+    # Asarray
+    stacked_arrays_local = stacked_arrays.asarray().get()
+    stacked_arrays_local_bench = np.hstack([
+        np.zeros(shape=distributed_array0.global_shape, dtype=par['dtype']).ravel(),
+        np.ones(shape=distributed_array1.global_shape, dtype=par['dtype']).ravel(),
+        2 * np.ones(shape=distributed_array2.global_shape, dtype=par['dtype']).ravel(),
+        ])
+    assert_allclose(stacked_arrays_local, stacked_arrays_local_bench, rtol=1e-14)
+
+    # Modify array in place
+    distributed_array0[:] = 2
+    assert_allclose(stacked_arrays[0][0].local_array.get(),
+                    2 * np.ones(shape=distributed_array0.local_shape,
+                                dtype=par['dtype']), rtol=1e-14)
+    distributed_array2[:] = 4
+    assert_allclose(stacked_arrays[1].local_array.get(),
+                    4 * np.ones(shape=distributed_array2.local_shape,
+                                dtype=par['dtype']), rtol=1e-14)
+
+
+@pytest.mark.mpi(min_size=2)
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2),
+                                 (par2j), (par3), (par3j)])
+def test_stacked_nested_math(par):
+    """Test Element-Wise Addition, Subtraction and Multiplication, Dot-product, Norm
+    for nested stacked distributed arrays"""
+    distributed_array0 = DistributedArray(global_shape=par['global_shape'],
+                                          partition=par['partition'],
+                                          dtype=par['dtype'], axis=par['axis'],
+                                          engine="cupy")
+    distributed_array1 = DistributedArray(global_shape=par['global_shape'],
+                                          partition=par['partition'],
+                                          dtype=par['dtype'], axis=par['axis'],
+                                          engine="cupy")
+    distributed_array2 = DistributedArray(global_shape=par['global_shape'],
+                                          partition=par['partition'],
+                                          dtype=par['dtype'], axis=par['axis'],
+                                          engine="cupy")
+    distributed_array0[:] = 0
+    distributed_array1[:] = cp.arange(np.prod(distributed_array1.local_shape)).reshape(distributed_array1.local_shape)
+    distributed_array2[:] = cp.ones(np.prod(distributed_array2.local_shape)).reshape(distributed_array1.local_shape)
+
+    stacked_array_01 = StackedDistributedArray([distributed_array0, distributed_array1])
+    stacked_array_12 = StackedDistributedArray([distributed_array1, distributed_array2])
+    stacked_array1 = StackedDistributedArray([stacked_array_01, distributed_array2])
+    stacked_array2 = StackedDistributedArray([stacked_array_12, distributed_array0])
+
+    # Addition
+    sum_array = stacked_array1 + stacked_array2
+    assert isinstance(sum_array, StackedDistributedArray)
+    assert_allclose(sum_array.asarray().get(), np.add(stacked_array1.asarray().get(),
+                                                      stacked_array2.asarray().get()),
+                    rtol=1e-14)
+    # Subtraction
+    sub_array = stacked_array1 - stacked_array2
+    assert isinstance(sub_array, StackedDistributedArray)
+    assert_allclose(sub_array.asarray().get(), np.subtract(stacked_array1.asarray().get(),
+                                                           stacked_array2.asarray().get()),
+                    rtol=1e-14)
+    # Multiplication
+    mult_array = stacked_array1 * stacked_array2
+    assert isinstance(mult_array, StackedDistributedArray)
+    assert_allclose(mult_array.asarray().get(), np.multiply(stacked_array1.asarray().get(),
+                                                            stacked_array2.asarray().get()),
+                    rtol=1e-14)
+    # Dot-product
+    dot_prod = stacked_array1.dot(stacked_array2)
+    assert_allclose(dot_prod.get(), np.dot(stacked_array1.asarray().flatten().get(),
+                                           stacked_array2.asarray().flatten().get()),
+                    rtol=1e-14)
+    # Norm
+    l0norm = stacked_array1.norm(0)
+    l1norm = stacked_array1.norm(1)
+    l2norm = stacked_array1.norm(2)
+    linfnorm = stacked_array1.norm(np.inf)
+
+    assert_allclose(l0norm.get(), np.linalg.norm(stacked_array1.asarray().flatten().get(), 0),
+                    rtol=1e-14)
+    assert_allclose(l1norm.get(), np.linalg.norm(stacked_array1.asarray().flatten().get(), 1),
+                    rtol=1e-14)
+    assert_allclose(l2norm.get(), np.linalg.norm(stacked_array1.asarray().get(), 2),
+                    rtol=1e-10)
     assert_allclose(linfnorm.get(), np.linalg.norm(stacked_array1.asarray().flatten().get(), np.inf),
                     rtol=1e-14)


### PR DESCRIPTION
## Motivation
This PR introduces support for nested `StackedDistributedArray`.

In other words, in the current setup one can stack multiple `DistributedArray` into a `StackedDistributedArray`. However as part of this effort to introduce support for distributed proximal operators and solvers in pylops-mpi, it turns out that in some scenarios one requires to created nested `StackedDistributedArray`, meaning that one of more elements of a `StackedDistributedArray` are `StackedDistributedArray` themselves. 

Some changes are required for basic operations (eg +, -, *) to work and this PR provides them.

## TO DO 
- [x] Add NCCL tests
- [x] Add example