### PR TITLE
Build: added pre-commit support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+exclude: "^docs/"
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        args: # arguments to configure black
+          - --line-length=88
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        name: isort (python)
+        args:
+          [
+            "--profile",
+            "black",
+            "--skip",
+            "__init__.py",
+            "--filter-files",
+            "--line-length=88",
+          ]

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -239,6 +239,22 @@ From then on, you can pull changes (for example, in the main branch) with:
 
    >> git pull upstream main
 
+Install pre-commit hooks
+========================
+To ensure consistency in the coding style of our developers we rely on
+`pre-commit <https://pre-commit.com>`_ to perform a series of checks when you are
+ready to commit and push some changes. This is accomplished by means of git hooks
+that have been configured in the ``.pre-commit-config.yaml`` file.
+
+In order to setup such hooks in your local repository, run:
+
+.. code-block:: bash
+
+   >> pre-commit install
+
+Once this is set up, when committing changes, ``pre-commit`` will reject and "fix" your code by running the proper hooks.
+At this point, the user must check the changes and then stage them before trying to commit again.
+
 Final steps
 ===========
 PyLops-MPI does not enforce the use of a linter as a pre-commit hook, but we do highly encourage using one before submitting a Pull Request.

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -20,6 +20,8 @@ dependencies:
   - numba
   - nbsphinx
   - pydata-sphinx-theme
+  - isort
+  - black
   - flake8
   - mpi4py-fft
   - pip:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,4 +11,6 @@ numpydoc
 numba
 nbsphinx
 sphinx_gallery
+isort
+black
 flake8


### PR DESCRIPTION
This PR adds minimal support for pre-commit as in PyLops <=v2.5.0 (the pre-commit setup in PyLops >v2.5.0 requires to be aligned with a full switch to uv/ruff which is not happening in this PR).