### PR TITLE
Prepare release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.7.0
+* Introduced `dims` and `dimsd` as parameters in `pylops_mpi.MPILinearOperator` and `pylops_mpi.MPIStackedLinearOperator`.
+* Added `dims` and `dimsd` to all the MPI Operators.
+* Added support for nested `pylops_mpi.StackedDistributedArray` and basic operations on them.
+* Added support for separable proximal operators through `pylops_mpi.proximal.MPIProxOperator` wrappers.
+* Implemented the distributed `pylops_mpi.proximal.proximal.MPIL2` proximal operator using distributed stacking and solvers.
+* Added distributed `pylops_mpi.proximal.optimization.ProximalGradient` and `pylops_mpi.proximal.optimization.ADMML2` solvers.
+* Added `local_array` as a new parameter to `pylops_mpi.DistributedArray`.
+
 # 0.6.1
 * Fixed import error in `pylops_mpi.optimization.cls_sparsity` and `pylops_mpi.optimization.sparsity`.
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,6 +3,19 @@
 Changelog
 =========
 
+Version 0.7.0
+-------------
+
+*Released on 13/08/2026*
+
+* Introduced `dims` and `dimsd` as parameters in :class:`pylops_mpi.MPILinearOperator` and :class:`pylops_mpi.MPIStackedLinearOperator`.
+* Added `dims` and `dimsd` to all the MPI Operators.
+* Added support for nested :class:`pylops_mpi.StackedDistributedArray` and basic operations on them.
+* Added support for separable proximal operators through :class:`pylops_mpi.proximal.MPIProxOperator` wrappers.
+* Implemented the distributed :class:`pylops_mpi.proximal.proximal.MPIL2` proximal operator using distributed stacking and solvers.
+* Added distributed :func:`pylops_mpi.proximal.optimization.ProximalGradient` and :func:`pylops_mpi.proximal.optimization.ADMML2` solvers.
+* Added `local_array` as a new parameter to :class:`pylops_mpi.DistributedArray`.
+
 Version 0.6.1
 -------------
 

--- a/tests/test_eigs.py
+++ b/tests/test_eigs.py
@@ -19,6 +19,7 @@ par1 = {"n": 21, "imag": 0, "dtype": "float64"}  # square, real
 par2 = {"n": 21, "imag": 1j, "dtype": "complex128"}  # square, complex
 
 
+@pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_power_iteration(par):
     """Max eigenvalue computation with power iteration method vs. numpy.linalg.eig"""
@@ -46,6 +47,7 @@ def test_power_iteration(par):
     assert np.abs(np.abs(eig) - eig_np) < 1e-3
 
 
+@pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_power_iteration_stacked(par):
     """Max eigenvalue computation with power iteration method vs. numpy.linalg.eig for MPIStackedBlockDiag"""

--- a/tests/test_ffts.py
+++ b/tests/test_ffts.py
@@ -89,6 +89,7 @@ par8 = {
 rank = MPI.COMM_WORLD.Get_rank()
 
 
+@pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
 @pytest.mark.parametrize(
     "ifftshift_before, fftshift_after",
@@ -127,6 +128,7 @@ def test_FFT2d(par, ifftshift_before, fftshift_after):
         assert_array_almost_equal(y_adj, y_adj_np, decimal=7)
 
 
+@pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6), (par7), (par8)])
 @pytest.mark.parametrize(
     "ifftshift_before, fftshift_after",

--- a/tests/test_linearop.py
+++ b/tests/test_linearop.py
@@ -379,6 +379,7 @@ def test_adj_mpilinop(par):
         assert_allclose(y, y_np.flatten(), rtol=1e-9)
 
 
+@pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
 def test_copy_dims_dimsd(par):
     """Apply various overloaded operators (.H, -, +, *) and ensure that the

--- a/tests/test_matrixmult.py
+++ b/tests/test_matrixmult.py
@@ -79,7 +79,7 @@ def _reorganize_local_matrix(x_dist, N, M, blk_cols, p_prime):
     return x
 
 
-@pytest.mark.mpi(min_size=1)
+@pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize("N, K, M, dtype_str", test_params)
 def test_MPIMatrixMult_block(N, K, M, dtype_str):
     """MPIMatrixMult operator with kind=`blocked`"""
@@ -196,7 +196,7 @@ def test_MPIMatrixMult_block(N, K, M, dtype_str):
             err_msg=f"Rank {rank}: Adjoint verification failed."
         )
 
-@pytest.mark.mpi(min_size=1)
+@pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize("N, K, M, dtype_str", test_params)
 def test_MPIMatrixMult_summa(N, K, M, dtype_str):
     """MPIMatrixMult operator with kind=`summa`"""

--- a/tests/test_nonstatconvolve.py
+++ b/tests/test_nonstatconvolve.py
@@ -84,6 +84,7 @@ def test_ih_irregular(par):
         )
 
 
+@pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize("par", [(par1_1d), (par2_1d)])
 def test_NonStationaryConvolve1D(par):
     """Dot-test and inversion for NonStationaryConvolve1D operator"""

--- a/tests/test_sparsity.py
+++ b/tests/test_sparsity.py
@@ -70,6 +70,7 @@ if backend == "cupy":
     np.cuda.Device(device_id).use()
 
 
+@pytest.mark.mpi(min_size=2)
 def test_ISTA_FISTA_unknown_threshkind():
     """Check error is raised if unknown threshkind is passed"""
     with pytest.raises(ValueError, match="threshkind must be"):
@@ -82,6 +83,7 @@ def test_ISTA_FISTA_unknown_threshkind():
         _ = fista(MPIBlockDiag(ops=[Identity(5)]), y, 10, threshkind="foo")
 
 
+@pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par1j), (par2j), (par3j)])
 def test_ISTA_FISTA_alpha_too_high(par):
     """Invert problem with ISTA/FISTA - alpha too high"""
@@ -129,6 +131,7 @@ def test_ISTA_FISTA_alpha_too_high(par):
         assert np.isnan(cost[-1]) or np.isinf(cost[-1])
 
 
+@pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize("par", [(par1), (par1j)])
 def test_ISTA_FISTA(par):
     """Invert problem with ISTA/FISTA"""
@@ -199,6 +202,7 @@ def test_ISTA_FISTA(par):
                 assert_allclose(xinv_array, xinv1, rtol=1e-8)
 
 
+@pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize("par", [(par2), (par2j)])
 def test_ISTA_FISTA_broadcastmodel(par):
     """Invert problem with ISTA/FISTA with broadcasted model"""
@@ -267,6 +271,7 @@ def test_ISTA_FISTA_broadcastmodel(par):
                 assert_allclose(xinv_array, xinv1, rtol=1e-8)
 
 
+@pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize("par", [(par3), (par3j)])
 def test_ISTA_FISTA_broadcastdata(par):
     """Invert problem with ISTA/FISTA with broadcasted data"""

--- a/tests/test_stackedlinearop.py
+++ b/tests/test_stackedlinearop.py
@@ -327,6 +327,7 @@ def test_product(par):
         assert_allclose(Pop_y_np, Pop.H @ y_global, rtol=1e-14)
 
 
+@pytest.mark.mpi(min_size=2)
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
 def test_copy_dims_dimsd(par):
     """Apply various overloaded operators (.H, -, +, *) and ensure that the


### PR DESCRIPTION
- Update changelog for release `v0.7.0`
- Update pytest params to work only when mpi_rank>=2.