### PR TITLE
Bug: changes to suppress deprecation warning on float of 1-element array

### DIFF
--- a/pylops_mpi/DistributedArray.py
+++ b/pylops_mpi/DistributedArray.py
@@ -4,19 +4,23 @@ from typing import Any, List, NewType, Optional, Self, Tuple, Union
 
 import numpy as np
 from mpi4py import MPI
-from pylops_mpi.Distributed import DistributedMixIn
 from pylops.utils import DTypeLike, NDArray
-from pylops.utils import deps as pylops_deps  # avoid namespace crashes with pylops_mpi.utils
+from pylops.utils import (
+    deps as pylops_deps,  # avoid namespace crashes with pylops_mpi.utils
+)
 from pylops.utils._internal import _value_or_sized_to_tuple
 from pylops.utils.backend import get_array_module, get_module, get_module_name
+
+from pylops_mpi.Distributed import DistributedMixIn
 from pylops_mpi.utils import deps
 
 cupy_message = pylops_deps.cupy_import("the DistributedArray module")
 nccl_message = deps.nccl_import("the DistributedArray module")
 
 if nccl_message is None and cupy_message is None:
-    from pylops_mpi.utils._nccl import nccl_asarray, nccl_split
     from cupy.cuda.nccl import NcclCommunicator
+
+    from pylops_mpi.utils._nccl import nccl_asarray, nccl_split
 else:
     NcclCommunicator = Any
 
@@ -39,8 +43,9 @@ class Partition(Enum):
     SCATTER = "Scatter"
 
 
-def local_split(global_shape: Tuple, base_comm: MPI.Comm,
-                partition: Partition, axis: int):
+def local_split(
+    global_shape: Tuple, base_comm: MPI.Comm, partition: Partition, axis: int
+):
     """To get the local shape from the global shape
 
     Parameters
@@ -71,7 +76,9 @@ def local_split(global_shape: Tuple, base_comm: MPI.Comm,
     return tuple(local_shape)
 
 
-def subcomm_split(mask, comm: Optional[Union[MPI.Comm, NcclCommunicatorType]] = MPI.COMM_WORLD):
+def subcomm_split(
+    mask, comm: Optional[Union[MPI.Comm, NcclCommunicatorType]] = MPI.COMM_WORLD
+):
     """Create new communicators based on mask
 
     This method creates new communicators based on ``mask``.
@@ -98,6 +105,30 @@ def subcomm_split(mask, comm: Optional[Union[MPI.Comm, NcclCommunicatorType]] = 
         rank = comm.Get_rank()
         sub_comm = comm.Split(color=mask[rank], key=rank)
     return sub_comm
+
+
+def to_scalar(x) -> Union[bool, int, float, complex]:
+    """Convert a size-1 array (or a scalar) into a Python scalar
+
+    Reductions over an entire distributed array (such as dot products and
+    norms) return a size-1 buffer for both the numpy and cupy backends. Such
+    buffers are converted into Python scalars to be consistent with the
+    return type of their numpy counterparts (e.g., :func:`numpy.linalg.norm`)
+    and to avoid deprecated implicit array-to-scalar conversions in the
+    callers. Note that the type of the scalar is preserved (e.g., a complex
+    dot product returns a :obj:`complex`).
+
+    Parameters
+    ----------
+    x : :obj:`numpy.ndarray` or :obj:`cupy.ndarray` or :obj:`float`
+        Size-1 array (or scalar) to convert.
+
+    Returns
+    -------
+    scalar : :obj:`bool` or :obj:`int` or :obj:`float` or :obj:`complex`
+        Converted scalar.
+    """
+    return x.item() if hasattr(x, "item") else x
 
 
 class DistributedArray(DistributedMixIn):
@@ -161,24 +192,36 @@ class DistributedArray(DistributedMixIn):
         expected local shape for the current rank.
     """
 
-    def __init__(self, global_shape: Union[Tuple, Integral],
-                 base_comm: Optional[MPI.Comm] = MPI.COMM_WORLD,
-                 base_comm_nccl: Optional[NcclCommunicatorType] = None,
-                 partition: Partition = Partition.SCATTER, axis: int = 0,
-                 local_array: Optional[NDArray] = None,
-                 local_shapes: Optional[List[Union[Tuple, Integral]]] = None,
-                 mask: Optional[List[Integral]] = None,
-                 engine: Optional[str] = "numpy",
-                 dtype: Optional[DTypeLike] = np.float64):
+    def __init__(
+        self,
+        global_shape: Union[Tuple, Integral],
+        base_comm: Optional[MPI.Comm] = MPI.COMM_WORLD,
+        base_comm_nccl: Optional[NcclCommunicatorType] = None,
+        partition: Partition = Partition.SCATTER,
+        axis: int = 0,
+        local_array: Optional[NDArray] = None,
+        local_shapes: Optional[List[Union[Tuple, Integral]]] = None,
+        mask: Optional[List[Integral]] = None,
+        engine: Optional[str] = "numpy",
+        dtype: Optional[DTypeLike] = np.float64,
+    ):
         if isinstance(global_shape, Integral):
             global_shape = (global_shape,)
         if len(global_shape) <= axis:
-            raise IndexError(f"Axis {axis} out of range for DistributedArray "
-                             f"of shape {global_shape}")
+            raise IndexError(
+                f"Axis {axis} out of range for DistributedArray "
+                f"of shape {global_shape}"
+            )
         if partition not in Partition:
-            raise ValueError(f"Should be either {Partition.BROADCAST}, "
-                             f"{Partition.UNSAFE_BROADCAST} or {Partition.SCATTER}")
-        self._engine = engine if local_array is None else get_module_name(get_array_module(local_array))
+            raise ValueError(
+                f"Should be either {Partition.BROADCAST}, "
+                f"{Partition.UNSAFE_BROADCAST} or {Partition.SCATTER}"
+            )
+        self._engine = (
+            engine
+            if local_array is None
+            else get_module_name(get_array_module(local_array))
+        )
         if base_comm_nccl and self._engine != "cupy":
             raise ValueError("NCCL Communicator only works with engine `cupy`")
         self.dtype = dtype if local_array is None else local_array.dtype
@@ -191,12 +234,24 @@ class DistributedArray(DistributedMixIn):
         self._partition = partition
         self._axis = axis
         self._mask = mask
-        self._sub_comm = (base_comm if base_comm_nccl is None else base_comm_nccl) if mask is None else subcomm_split(
-            mask, (base_comm if base_comm_nccl is None else base_comm_nccl))
-        local_shapes = local_shapes if local_shapes is None else [_value_or_sized_to_tuple(local_shape) for local_shape in local_shapes]
+        self._sub_comm = (
+            (base_comm if base_comm_nccl is None else base_comm_nccl)
+            if mask is None
+            else subcomm_split(
+                mask, (base_comm if base_comm_nccl is None else base_comm_nccl)
+            )
+        )
+        local_shapes = (
+            local_shapes
+            if local_shapes is None
+            else [_value_or_sized_to_tuple(local_shape) for local_shape in local_shapes]
+        )
         self._check_local_shapes(local_shapes)
-        self._local_shape = local_shapes[self.rank] if local_shapes else local_split(global_shape, base_comm,
-                                                                                     partition, axis)
+        self._local_shape = (
+            local_shapes[self.rank]
+            if local_shapes
+            else local_split(global_shape, base_comm, partition, axis)
+        )
 
         if local_array is None:
             self._local_array = get_module(self._engine).empty(
@@ -241,11 +296,7 @@ class DistributedArray(DistributedMixIn):
             if self.rank == 0:
                 buf[...] = value
             buf = self._bcast(
-                self.base_comm,
-                self.base_comm_nccl,
-                buf,
-                root=0,
-                engine=self.engine
+                self.base_comm, self.base_comm_nccl, buf, root=0, engine=self.engine
             )
             self.local_array[index] = buf
         else:
@@ -384,9 +435,9 @@ class DistributedArray(DistributedMixIn):
         if deps.nccl_enabled and getattr(self, "base_comm_nccl"):
             return self._nccl_local_shapes(False)
         else:
-            return self._allgather(self.base_comm,
-                                   self.base_comm_nccl,
-                                   self.local_shape)
+            return self._allgather(
+                self.base_comm, self.base_comm_nccl, self.local_shape
+            )
 
     @property
     def sub_comm(self):
@@ -419,30 +470,41 @@ class DistributedArray(DistributedMixIn):
             return self.local_array
 
         if deps.nccl_enabled and getattr(self, "base_comm_nccl"):
-            return nccl_asarray(self.sub_comm if masked else self.base_comm_nccl,
-                                self.local_array, self._nccl_local_shapes(masked), self.axis)
+            return nccl_asarray(
+                self.sub_comm if masked else self.base_comm_nccl,
+                self.local_array,
+                self._nccl_local_shapes(masked),
+                self.axis,
+            )
         else:
             # Gather all the local arrays and apply concatenation.
             if masked:
-                final_array = self._allgather_subcomm(self.sub_comm,
-                                                      self.base_comm_nccl,
-                                                      self.local_array,
-                                                      engine=self.engine)
+                final_array = self._allgather_subcomm(
+                    self.sub_comm,
+                    self.base_comm_nccl,
+                    self.local_array,
+                    engine=self.engine,
+                )
             else:
-                final_array = self._allgather(self.base_comm,
-                                              self.base_comm_nccl,
-                                              self.local_array,
-                                              engine=self.engine)
+                final_array = self._allgather(
+                    self.base_comm,
+                    self.base_comm_nccl,
+                    self.local_array,
+                    engine=self.engine,
+                )
             return np.concatenate(final_array, axis=self.axis)
 
     @classmethod
-    def to_dist(cls, x: NDArray,
-                base_comm: MPI.Comm = MPI.COMM_WORLD,
-                base_comm_nccl: NcclCommunicatorType = None,
-                partition: Partition = Partition.SCATTER,
-                axis: int = 0,
-                local_shapes: Optional[List[Tuple]] = None,
-                mask: Optional[List[Integral]] = None):
+    def to_dist(
+        cls,
+        x: NDArray,
+        base_comm: MPI.Comm = MPI.COMM_WORLD,
+        base_comm_nccl: NcclCommunicatorType = None,
+        partition: Partition = Partition.SCATTER,
+        axis: int = 0,
+        local_shapes: Optional[List[Tuple]] = None,
+        mask: Optional[List[Integral]] = None,
+    ):
         """Convert A Global Array to a Distributed Array
 
         Parameters
@@ -468,25 +530,31 @@ class DistributedArray(DistributedMixIn):
         dist_array : :obj:`DistributedArray`
             Distributed Array of the Global Array
         """
-        dist_array = DistributedArray(global_shape=x.shape,
-                                      base_comm=base_comm,
-                                      base_comm_nccl=base_comm_nccl,
-                                      partition=partition,
-                                      axis=axis,
-                                      local_shapes=local_shapes,
-                                      mask=mask,
-                                      engine=get_module_name(get_array_module(x)),
-                                      dtype=x.dtype)
+        dist_array = DistributedArray(
+            global_shape=x.shape,
+            base_comm=base_comm,
+            base_comm_nccl=base_comm_nccl,
+            partition=partition,
+            axis=axis,
+            local_shapes=local_shapes,
+            mask=mask,
+            engine=get_module_name(get_array_module(x)),
+            dtype=x.dtype,
+        )
         if partition in [Partition.BROADCAST, Partition.UNSAFE_BROADCAST]:
             dist_array[:] = x
         else:
             slices = [slice(None)] * x.ndim
-            local_shapes = np.append([0], dist_array._allgather(
-                base_comm, base_comm_nccl,
-                dist_array.local_shape[axis]))
+            local_shapes = np.append(
+                [0],
+                dist_array._allgather(
+                    base_comm, base_comm_nccl, dist_array.local_shape[axis]
+                ),
+            )
             sum_shapes = np.cumsum(local_shapes)
-            slices[axis] = slice(sum_shapes[dist_array.rank],
-                                 sum_shapes[dist_array.rank + 1], None)
+            slices[axis] = slice(
+                sum_shapes[dist_array.rank], sum_shapes[dist_array.rank + 1], None
+            )
             dist_array[:] = x[tuple(slices)]
         return dist_array
 
@@ -516,9 +584,15 @@ class DistributedArray(DistributedMixIn):
         if self.axis == axis or self.partition is not Partition.SCATTER:
             return self
         ncp = get_module(self.engine)
-        redist_array = DistributedArray(global_shape=self.global_shape, base_comm=self.base_comm,
-                                        base_comm_nccl=self.base_comm_nccl, mask=self.mask, axis=axis,
-                                        engine=self.engine, dtype=self.dtype)
+        redist_array = DistributedArray(
+            global_shape=self.global_shape,
+            base_comm=self.base_comm,
+            base_comm_nccl=self.base_comm_nccl,
+            mask=self.mask,
+            axis=axis,
+            engine=self.engine,
+            dtype=self.dtype,
+        )
         counts_from = [x[self.axis] for x in self.local_shapes]
         counts_to = [x[axis] for x in redist_array.local_shapes]
         offsets_to = ncp.cumsum(ncp.array([0] + counts_to[:-1]))
@@ -539,14 +613,17 @@ class DistributedArray(DistributedMixIn):
             if r == self.rank:
                 recv_buf[:] = send_slices[self.rank]
             else:
-                recv_buf = self._sendrecv(base_comm=self.base_comm,
-                                          base_comm_nccl=self.base_comm_nccl,
-                                          sendbuf=send_slices[r],
-                                          dest=r,
-                                          sendtag=0,
-                                          recvbuf=recv_buf,
-                                          source=r,
-                                          recvtag=0, engine=self.engine)
+                recv_buf = self._sendrecv(
+                    base_comm=self.base_comm,
+                    base_comm_nccl=self.base_comm_nccl,
+                    sendbuf=send_slices[r],
+                    dest=r,
+                    sendtag=0,
+                    recvbuf=recv_buf,
+                    source=r,
+                    recvtag=0,
+                    engine=self.engine,
+                )
             recv_list.append(recv_buf)
         redist_array[:] = ncp.concatenate(recv_list, axis=self.axis)
         return redist_array
@@ -555,63 +632,80 @@ class DistributedArray(DistributedMixIn):
         """Check if the local shapes align with the global shape"""
         if local_shapes:
             if len(local_shapes) != self.size:
-                raise ValueError(f"Length of local shapes is not equal to number of processes; "
-                                 f"{len(local_shapes)} != {self.size}")
+                raise ValueError(
+                    f"Length of local shapes is not equal to number of processes; "
+                    f"{len(local_shapes)} != {self.size}"
+                )
             # Check if local shape == global shape
-            if self.partition in [Partition.BROADCAST, Partition.UNSAFE_BROADCAST] and local_shapes[self.rank] != self.global_shape:
-                raise ValueError(f"Local shape is not equal to global shape at rank = {self.rank};"
-                                 f"{local_shapes[self.rank]} != {self.global_shape}")
+            if (
+                self.partition in [Partition.BROADCAST, Partition.UNSAFE_BROADCAST]
+                and local_shapes[self.rank] != self.global_shape
+            ):
+                raise ValueError(
+                    f"Local shape is not equal to global shape at rank = {self.rank};"
+                    f"{local_shapes[self.rank]} != {self.global_shape}"
+                )
             elif self.partition is Partition.SCATTER:
                 local_shape = local_shapes[self.rank]
                 # Check if local shape sum up to global shape and other dimensions align with global shape
-                if self.base_comm.allreduce(local_shape[self.axis]) != self.global_shape[self.axis] or \
-                        not np.array_equal(np.delete(local_shape, self.axis), np.delete(self.global_shape, self.axis)):
-                    raise ValueError(f"Local shapes don't align with the global shape;"
-                                     f"{local_shapes} != {self.global_shape}")
+                if self.base_comm.allreduce(
+                    local_shape[self.axis]
+                ) != self.global_shape[self.axis] or not np.array_equal(
+                    np.delete(local_shape, self.axis),
+                    np.delete(self.global_shape, self.axis),
+                ):
+                    raise ValueError(
+                        f"Local shapes don't align with the global shape;"
+                        f"{local_shapes} != {self.global_shape}"
+                    )
 
     def _check_partition_shape(self, dist_array):
-        """Check Partition and Local Shape of the Array
-        """
+        """Check Partition and Local Shape of the Array"""
         if self.partition != dist_array.partition:
             raise ValueError("Partition of both the arrays must be same")
         if self.local_shape != dist_array.local_shape:
-            raise ValueError(f"Local Array Shape Mismatch - "
-                             f"{self.local_shape} != {dist_array.local_shape}")
+            raise ValueError(
+                f"Local Array Shape Mismatch - "
+                f"{self.local_shape} != {dist_array.local_shape}"
+            )
 
     def _check_mask(self, dist_array):
-        """Check mask of the Array
-        """
+        """Check mask of the Array"""
         if not np.array_equal(self.mask, dist_array.mask):
             raise ValueError("Mask of both the arrays must be same")
 
     def _nccl_local_shapes(self, masked: bool):
-        """Get the the list of shapes of every GPU in the communicator
-        """
+        """Get the the list of shapes of every GPU in the communicator"""
         # gather tuple of shapes from every rank within thee communicator and copy from GPU to CPU
         if masked:
-            all_tuples = self._allgather_subcomm(self.sub_comm,
-                                                 self.base_comm_nccl,
-                                                 self.local_shape).get()
+            all_tuples = self._allgather_subcomm(
+                self.sub_comm, self.base_comm_nccl, self.local_shape
+            ).get()
         else:
-            all_tuples = self._allgather(self.base_comm,
-                                         self.base_comm_nccl,
-                                         self.local_shape).get()
+            all_tuples = self._allgather(
+                self.base_comm, self.base_comm_nccl, self.local_shape
+            ).get()
         # NCCL returns the flat array that packs every tuple as 1-dimensional array
         # unpack each tuple from each rank
         tuple_len = len(self.local_shape)
-        local_shapes = [tuple(all_tuples[i : i + tuple_len]) for i in range(0, len(all_tuples), tuple_len)]
+        local_shapes = [
+            tuple(all_tuples[i : i + tuple_len])
+            for i in range(0, len(all_tuples), tuple_len)
+        ]
         return local_shapes
 
     def __neg__(self):
-        arr = DistributedArray(global_shape=self.global_shape,
-                               base_comm=self.base_comm,
-                               base_comm_nccl=self.base_comm_nccl,
-                               partition=self.partition,
-                               axis=self.axis,
-                               local_shapes=self.local_shapes,
-                               mask=self.mask,
-                               engine=self.engine,
-                               dtype=self.dtype)
+        arr = DistributedArray(
+            global_shape=self.global_shape,
+            base_comm=self.base_comm,
+            base_comm_nccl=self.base_comm_nccl,
+            partition=self.partition,
+            axis=self.axis,
+            local_shapes=self.local_shapes,
+            mask=self.mask,
+            engine=self.engine,
+            dtype=self.dtype,
+        )
         arr[:] = -self.local_array
         return arr
 
@@ -634,46 +728,53 @@ class DistributedArray(DistributedMixIn):
         return self.multiply(x)
 
     def add(self, dist_array):
-        """Distributed Addition of arrays
-        """
-        self._check_partition_shape(dist_array)
-        self._check_mask(dist_array)
-        SumArray = DistributedArray(global_shape=self.global_shape,
-                                    base_comm=self.base_comm,
-                                    base_comm_nccl=self.base_comm_nccl,
-                                    dtype=self.dtype,
-                                    partition=self.partition,
-                                    local_shapes=self.local_shapes,
-                                    mask=self.mask,
-                                    engine=self.engine,
-                                    axis=self.axis)
-        SumArray[:] = self.local_array + dist_array.local_array
+        """Distributed Addition of arrays"""
+        if isinstance(dist_array, DistributedArray):
+            self._check_partition_shape(dist_array)
+            self._check_mask(dist_array)
+        SumArray = DistributedArray(
+            global_shape=self.global_shape,
+            base_comm=self.base_comm,
+            base_comm_nccl=self.base_comm_nccl,
+            dtype=self.dtype,
+            partition=self.partition,
+            local_shapes=self.local_shapes,
+            mask=self.mask,
+            engine=self.engine,
+            axis=self.axis,
+        )
+        if isinstance(dist_array, DistributedArray):
+            # sum two DistributedArray
+            SumArray[:] = self.local_array + dist_array.local_array
+        else:
+            # SUum with scalar
+            SumArray[:] = self.local_array + dist_array
         return SumArray
 
     def iadd(self, dist_array):
-        """Distributed In-place Addition of arrays
-        """
+        """Distributed In-place Addition of arrays"""
         self._check_partition_shape(dist_array)
         self._check_mask(dist_array)
         self[:] = self.local_array + dist_array.local_array
         return self
 
     def multiply(self, dist_array):
-        """Distributed Element-wise multiplication
-        """
+        """Distributed Element-wise multiplication"""
         if isinstance(dist_array, DistributedArray):
             self._check_partition_shape(dist_array)
             self._check_mask(dist_array)
 
-        ProductArray = DistributedArray(global_shape=self.global_shape,
-                                        base_comm=self.base_comm,
-                                        base_comm_nccl=self.base_comm_nccl,
-                                        dtype=self.dtype,
-                                        partition=self.partition,
-                                        local_shapes=self.local_shapes,
-                                        mask=self.mask,
-                                        engine=self.engine,
-                                        axis=self.axis)
+        ProductArray = DistributedArray(
+            global_shape=self.global_shape,
+            base_comm=self.base_comm,
+            base_comm_nccl=self.base_comm_nccl,
+            dtype=self.dtype,
+            partition=self.partition,
+            local_shapes=self.local_shapes,
+            mask=self.mask,
+            engine=self.engine,
+            axis=self.axis,
+        )
         if isinstance(dist_array, DistributedArray):
             # multiply two DistributedArray
             ProductArray[:] = self.local_array * dist_array.local_array
@@ -699,25 +800,47 @@ class DistributedArray(DistributedMixIn):
 
         Returns
         -------
-        result : float
+        result : :obj:`float` or :obj:`complex`
             The result of the dot product across all ranks. This is reduced across all processes.
         """
         self._check_partition_shape(dist_array)
         self._check_mask(dist_array)
         ncp = get_module(self.engine)
         # Convert to Partition.SCATTER if Partition.BROADCAST
-        x = DistributedArray.to_dist(x=self.local_array, base_comm=self.base_comm, base_comm_nccl=self.base_comm_nccl) \
-            if self.partition in [Partition.BROADCAST, Partition.UNSAFE_BROADCAST] else self
-        y = DistributedArray.to_dist(x=dist_array.local_array, base_comm=self.base_comm, base_comm_nccl=self.base_comm_nccl) \
-            if self.partition in [Partition.BROADCAST, Partition.UNSAFE_BROADCAST] else dist_array
-        # Flatten the local arrays and calculate dot product
+        x = (
+            DistributedArray.to_dist(
+                x=self.local_array,
+                base_comm=self.base_comm,
+                base_comm_nccl=self.base_comm_nccl,
+            )
+            if self.partition in [Partition.BROADCAST, Partition.UNSAFE_BROADCAST]
+            else self
+        )
+        y = (
+            DistributedArray.to_dist(
+                x=dist_array.local_array,
+                base_comm=self.base_comm,
+                base_comm_nccl=self.base_comm_nccl,
+            )
+            if self.partition in [Partition.BROADCAST, Partition.UNSAFE_BROADCAST]
+            else dist_array
+        )
+        # Flatten the local arrays and calculate dot product. Note that
+        # _allreduce_subcomm returns a size-1 array, which is converted
+        # into a scalar to be consistent with numpy.dot/numpy.vdot
         dot_func = ncp.vdot if vdot else ncp.dot
-        return self._allreduce_subcomm(self.sub_comm, self.base_comm_nccl,
-                                       dot_func(x.local_array.flatten(), y.local_array.flatten()),
-                                       engine=self.engine)
+        return to_scalar(
+            self._allreduce_subcomm(
+                self.sub_comm,
+                self.base_comm_nccl,
+                dot_func(x.local_array.flatten(), y.local_array.flatten()),
+                engine=self.engine,
+            )
+        )
 
-    def _compute_vector_norm(self, local_array: NDArray,
-                             axis: int, ord: Optional[int] = None):
+    def _compute_vector_norm(
+        self, local_array: NDArray, axis: int, ord: Optional[int] = None
+    ):
         """Compute Vector norm using MPI
 
         Parameters
@@ -738,29 +861,46 @@ class DistributedArray(DistributedMixIn):
             global_shape = list(self.global_shape)
             global_shape[axis] = 1
             recv_buf = ncp.empty(shape=global_shape, dtype=ncp.float64)
-        if ord in ['fro', 'nuc']:
+        if ord in ["fro", "nuc"]:
             raise ValueError(f"norm-{ord} not possible for vectors")
         elif ord == 0:
             # Count non-zero then sum reduction
-            recv_buf = self._allreduce_subcomm(self.sub_comm, self.base_comm_nccl,
-                                               ncp.count_nonzero(local_array, axis=axis).astype(ncp.float64),
-                                               engine=self.engine)
+            recv_buf = self._allreduce_subcomm(
+                self.sub_comm,
+                self.base_comm_nccl,
+                ncp.count_nonzero(local_array, axis=axis).astype(ncp.float64),
+                engine=self.engine,
+            )
         elif ord == ncp.inf:
             # Calculate max followed by max reduction
             # CuPy + non-CUDA-aware MPI does not work well with buffered communication, particularly
             # with MAX, MIN operator. Here we copy the array back to CPU, transfer, and copy them back to GPUs
             send_buf = ncp.max(ncp.abs(local_array), axis=axis).astype(ncp.float64)
-            if self.engine == "cupy" and self.base_comm_nccl is None and not deps.cuda_aware_mpi_enabled:
+            if (
+                self.engine == "cupy"
+                and self.base_comm_nccl is None
+                and not deps.cuda_aware_mpi_enabled
+            ):
                 # CuPy + non-CUDA-aware MPI: This will call non-buffered communication
                 # which return a list of object - must be copied back to a GPU memory.
-                recv_buf = self._allreduce_subcomm(self.sub_comm, self.base_comm_nccl,
-                                                   send_buf.get(), recv_buf.get(),
-                                                   op=MPI.MAX, engine=self.engine)
+                recv_buf = self._allreduce_subcomm(
+                    self.sub_comm,
+                    self.base_comm_nccl,
+                    send_buf.get(),
+                    recv_buf.get(),
+                    op=MPI.MAX,
+                    engine=self.engine,
+                )
                 recv_buf = ncp.asarray(ncp.squeeze(recv_buf, axis=axis))
             else:
-                recv_buf = self._allreduce_subcomm(self.sub_comm, self.base_comm_nccl,
-                                                   send_buf, recv_buf, op=MPI.MAX,
-                                                   engine=self.engine)
+                recv_buf = self._allreduce_subcomm(
+                    self.sub_comm,
+                    self.base_comm_nccl,
+                    send_buf,
+                    recv_buf,
+                    op=MPI.MAX,
+                    engine=self.engine,
+                )
                 # TODO (tharitt): In current implementation, there seems to be a semantic difference between Buffered MPI and NCCL
                 # the (1, size) is collapsed to (size, ) with buffered MPI while NCCL retains it.
                 # There may be a way to unify it - may be something to do with how we allocate the recv_buf.
@@ -770,40 +910,59 @@ class DistributedArray(DistributedMixIn):
             # Calculate min followed by min reduction
             # See the comment above in +infinity norm
             send_buf = ncp.min(ncp.abs(local_array), axis=axis).astype(ncp.float64)
-            if self.engine == "cupy" and self.base_comm_nccl is None and not deps.cuda_aware_mpi_enabled:
-                recv_buf = self._allreduce_subcomm(self.sub_comm, self.base_comm_nccl,
-                                                   send_buf.get(), recv_buf.get(),
-                                                   op=MPI.MIN, engine=self.engine)
+            if (
+                self.engine == "cupy"
+                and self.base_comm_nccl is None
+                and not deps.cuda_aware_mpi_enabled
+            ):
+                recv_buf = self._allreduce_subcomm(
+                    self.sub_comm,
+                    self.base_comm_nccl,
+                    send_buf.get(),
+                    recv_buf.get(),
+                    op=MPI.MIN,
+                    engine=self.engine,
+                )
                 recv_buf = ncp.asarray(ncp.squeeze(recv_buf, axis=axis))
             else:
-                recv_buf = self._allreduce_subcomm(self.sub_comm, self.base_comm_nccl,
-                                                   send_buf, recv_buf,
-                                                   op=MPI.MIN, engine=self.engine)
+                recv_buf = self._allreduce_subcomm(
+                    self.sub_comm,
+                    self.base_comm_nccl,
+                    send_buf,
+                    recv_buf,
+                    op=MPI.MIN,
+                    engine=self.engine,
+                )
                 if self.base_comm_nccl:
                     recv_buf = ncp.asarray(ncp.squeeze(recv_buf, axis=axis))
         else:
-            recv_buf = self._allreduce_subcomm(self.sub_comm, self.base_comm_nccl,
-                                               ncp.sum(ncp.abs(ncp.float_power(local_array, ord)), axis=axis),
-                                               engine=self.engine)
+            recv_buf = self._allreduce_subcomm(
+                self.sub_comm,
+                self.base_comm_nccl,
+                ncp.sum(ncp.abs(ncp.float_power(local_array, ord)), axis=axis),
+                engine=self.engine,
+            )
             recv_buf = ncp.power(recv_buf, 1.0 / ord)
         return recv_buf
 
     def zeros_like(self):
-        """Creates a copy of the DistributedArray filled with zeros
-        """
-        arr = DistributedArray(global_shape=self.global_shape,
-                               base_comm=self.base_comm,
-                               base_comm_nccl=self.base_comm_nccl,
-                               partition=self.partition,
-                               axis=self.axis,
-                               local_shapes=self.local_shapes,
-                               engine=self.engine,
-                               dtype=self.dtype)
-        arr[:] = 0.
+        """Creates a copy of the DistributedArray filled with zeros"""
+        arr = DistributedArray(
+            global_shape=self.global_shape,
+            base_comm=self.base_comm,
+            base_comm_nccl=self.base_comm_nccl,
+            partition=self.partition,
+            axis=self.axis,
+            local_shapes=self.local_shapes,
+            engine=self.engine,
+            dtype=self.dtype,
+        )
+        arr[:] = 0.0
         return arr
 
-    def norm(self, ord: Optional[int] = None,
-             axis: Optional[int] = None) -> Union[float, NDArray]:
+    def norm(
+        self, ord: Optional[int] = None, axis: Optional[int] = None
+    ) -> Union[float, NDArray]:
         """Distributed numpy.linalg.norm method
 
         Parameters
@@ -817,56 +976,75 @@ class DistributedArray(DistributedMixIn):
         Returns
         -------
         norm : :obj:`float` or :obj:`numpy.ndarray`
-            The computed norm of the distributed array.
+            The computed norm of the distributed array. A scalar is returned
+            when ``axis=None``, an array otherwise.
         """
         # Convert to Partition.SCATTER if Partition.BROADCAST
-        x = DistributedArray.to_dist(x=self.local_array, base_comm=self.base_comm, base_comm_nccl=self.base_comm_nccl) \
-            if self.partition in [Partition.BROADCAST, Partition.UNSAFE_BROADCAST] else self
+        x = (
+            DistributedArray.to_dist(
+                x=self.local_array,
+                base_comm=self.base_comm,
+                base_comm_nccl=self.base_comm_nccl,
+            )
+            if self.partition in [Partition.BROADCAST, Partition.UNSAFE_BROADCAST]
+            else self
+        )
         if axis is None:
-            # Flatten the local arrays and calculate norm
-            return x._compute_vector_norm(x.local_array.flatten(), axis=0, ord=ord)
+            # Flatten the local arrays and calculate norm. Note that
+            # _compute_vector_norm returns a size-1 array, which is converted
+            # into a scalar to be consistent with numpy.linalg.norm
+            return to_scalar(
+                x._compute_vector_norm(x.local_array.flatten(), axis=0, ord=ord)
+            )
         if axis >= self.ndim:
-            raise ValueError(f"axis={axis} is out of range for array of dimension {self.ndim}")
+            raise ValueError(
+                f"axis={axis} is out of range for array of dimension {self.ndim}"
+            )
         if self.axis != axis:
             ncp = get_module(self.engine)
             norm_axis = self.axis - 1 if axis < self.axis else self.axis
-            recv_buf = self._allgather(self.base_comm, self.base_comm_nccl,
-                                       ncp.linalg.norm(self.local_array, axis=axis, ord=ord),
-                                       engine=self.engine)
+            recv_buf = self._allgather(
+                self.base_comm,
+                self.base_comm_nccl,
+                ncp.linalg.norm(self.local_array, axis=axis, ord=ord),
+                engine=self.engine,
+            )
             return ncp.concatenate(recv_buf, axis=norm_axis)
         # Calculate vector norm along the axis
         return x._compute_vector_norm(x.local_array, axis=axis, ord=ord)
 
     def conj(self):
-        """Distributed conj() method
-        """
+        """Distributed conj() method"""
         local_array = self.local_array.conj()
-        conj = DistributedArray(global_shape=self.global_shape,
-                                base_comm=self.base_comm,
-                                base_comm_nccl=self.base_comm_nccl,
-                                partition=self.partition,
-                                axis=self.axis,
-                                local_array=local_array,
-                                local_shapes=self.local_shapes,
-                                mask=self.mask,
-                                engine=self.engine,
-                                dtype=self.dtype)
+        conj = DistributedArray(
+            global_shape=self.global_shape,
+            base_comm=self.base_comm,
+            base_comm_nccl=self.base_comm_nccl,
+            partition=self.partition,
+            axis=self.axis,
+            local_array=local_array,
+            local_shapes=self.local_shapes,
+            mask=self.mask,
+            engine=self.engine,
+            dtype=self.dtype,
+        )
         return conj
 
     def copy(self):
-        """Creates a copy of the DistributedArray
-        """
+        """Creates a copy of the DistributedArray"""
         local_array = self.local_array.copy()
-        arr = DistributedArray(global_shape=self.global_shape,
-                               base_comm=self.base_comm,
-                               base_comm_nccl=self.base_comm_nccl,
-                               partition=self.partition,
-                               axis=self.axis,
-                               local_array=local_array,
-                               local_shapes=self.local_shapes,
-                               mask=self.mask,
-                               engine=self.engine,
-                               dtype=self.dtype)
+        arr = DistributedArray(
+            global_shape=self.global_shape,
+            base_comm=self.base_comm,
+            base_comm_nccl=self.base_comm_nccl,
+            partition=self.partition,
+            axis=self.axis,
+            local_array=local_array,
+            local_shapes=self.local_shapes,
+            mask=self.mask,
+            engine=self.engine,
+            dtype=self.dtype,
+        )
         return arr
 
     def ravel(self, order: Optional[str] = "C"):
@@ -883,17 +1061,21 @@ class DistributedArray(DistributedMixIn):
         arr : :obj:`pylops_mpi.DistributedArray`
             Flattened 1-D DistributedArray
         """
-        local_shapes = [(np.prod(local_shape, axis=-1), ) for local_shape in self.local_shapes]
+        local_shapes = [
+            (np.prod(local_shape, axis=-1),) for local_shape in self.local_shapes
+        ]
         local_array = np.ravel(self.local_array, order=order)
-        arr = DistributedArray(global_shape=np.prod(self.global_shape),
-                               base_comm=self.base_comm,
-                               base_comm_nccl=self.base_comm_nccl,
-                               local_array=local_array,
-                               local_shapes=local_shapes,
-                               mask=self.mask,
-                               partition=self.partition,
-                               engine=self.engine,
-                               dtype=self.dtype)
+        arr = DistributedArray(
+            global_shape=np.prod(self.global_shape),
+            base_comm=self.base_comm,
+            base_comm_nccl=self.base_comm_nccl,
+            local_array=local_array,
+            local_shapes=local_shapes,
+            mask=self.mask,
+            partition=self.partition,
+            engine=self.engine,
+            dtype=self.dtype,
+        )
         return arr
 
     def reshape(self, local_shape: Tuple, axis: Optional[int] = 0):
@@ -918,7 +1100,10 @@ class DistributedArray(DistributedMixIn):
         global_shape = list(local_shapes[0])
         ref_shape = local_shapes[0]
         if self.partition is Partition.SCATTER:
-            if local_shape[:axis] != ref_shape[:axis] or local_shape[axis + 1:] != ref_shape[axis + 1:]:
+            if (
+                local_shape[:axis] != ref_shape[:axis]
+                or local_shape[axis + 1 :] != ref_shape[axis + 1 :]
+            ):
                 raise ValueError(
                     f"All local shapes must match on every axis except axis={axis}. "
                     f"Got {local_shape} in rank {self.rank} and {ref_shape} in rank 0."
@@ -932,28 +1117,37 @@ class DistributedArray(DistributedMixIn):
                     f"Got {local_shape} in rank {self.rank} and {ref_shape} in rank 0."
                 )
         local_array = self.local_array.reshape(local_shapes[self.rank])
-        arr = DistributedArray(global_shape=tuple(global_shape),
-                               base_comm=self.base_comm,
-                               base_comm_nccl=self.base_comm_nccl,
-                               local_shapes=local_shapes,
-                               mask=self.mask,
-                               partition=self.partition,
-                               engine=self.engine,
-                               dtype=self.dtype,
-                               local_array=local_array)
+        arr = DistributedArray(
+            global_shape=tuple(global_shape),
+            base_comm=self.base_comm,
+            base_comm_nccl=self.base_comm_nccl,
+            local_shapes=local_shapes,
+            mask=self.mask,
+            partition=self.partition,
+            engine=self.engine,
+            dtype=self.dtype,
+            local_array=local_array,
+        )
         return arr
 
     def empty_like(self):
-        """Creates an empty like DistributedArray with uninitialized values
-        """
-        dist = DistributedArray(global_shape=self.global_shape, base_comm=self.base_comm,
-                                base_comm_nccl=self.base_comm_nccl, partition=self.partition,
-                                axis=self.axis, local_shapes=self.local_shapes, mask=self.mask,
-                                engine=self.engine, dtype=self.dtype)
+        """Creates an empty like DistributedArray with uninitialized values"""
+        dist = DistributedArray(
+            global_shape=self.global_shape,
+            base_comm=self.base_comm,
+            base_comm_nccl=self.base_comm_nccl,
+            partition=self.partition,
+            axis=self.axis,
+            local_shapes=self.local_shapes,
+            mask=self.mask,
+            engine=self.engine,
+            dtype=self.dtype,
+        )
         return dist
 
-    def add_ghost_cells(self, cells_front: Optional[int] = None,
-                        cells_back: Optional[int] = None):
+    def add_ghost_cells(
+        self, cells_front: Optional[int] = None, cells_back: Optional[int] = None
+    ):
         """Add ghost cells to the DistributedArray along the axis
         of partition at each rank.
 
@@ -978,7 +1172,9 @@ class DistributedArray(DistributedMixIn):
             total_cells_front = self.base_comm.allgather(cells_front) + [0]
             # Read cells_front which needs to be sent to rank + 1(cells_front for rank + 1)
             cells_front = total_cells_front[self.rank + 1]
-            send_buf = ncp.take(self.local_array, ncp.arange(-cells_front, 0), axis=self.axis)
+            send_buf = ncp.take(
+                self.local_array, ncp.arange(-cells_front, 0), axis=self.axis
+            )
             recv_shapes = self.local_shapes
             if self.rank != 0:
                 # from receiver's perspective (rank), the recv buffer have the same shape as the sender's array (rank-1)
@@ -989,53 +1185,90 @@ class DistributedArray(DistributedMixIn):
                 # Transfer of ghost cells can be skipped if len(recv_buf) = 0
                 # Additionally, NCCL will hang if the buffer size is 0 so this optimization is somewhat mandatory
                 if len(recv_buf) != 0:
-                    ghosted_array = ncp.concatenate([self._recv(self.base_comm, self.base_comm_nccl,
-                                                                recv_buf, source=self.rank - 1, tag=1,
-                                                                engine=self.engine), ghosted_array], axis=self.axis)
+                    ghosted_array = ncp.concatenate(
+                        [
+                            self._recv(
+                                self.base_comm,
+                                self.base_comm_nccl,
+                                recv_buf,
+                                source=self.rank - 1,
+                                tag=1,
+                                engine=self.engine,
+                            ),
+                            ghosted_array,
+                        ],
+                        axis=self.axis,
+                    )
             # The skip in sender is to match with what described in receiver
             if self.rank != self.size - 1 and len(send_buf) != 0:
                 if cells_front > self.local_shape[self.axis]:
-                    raise ValueError(f"Local Shape at rank={self.rank} along axis={self.axis} "
-                                     f"should be > {cells_front}: dim({self.axis}) "
-                                     f"{self.local_shape[self.axis]} < {cells_front}; "
-                                     f"to achieve this use NUM_PROCESSES <= "
-                                     f"{max(1, self.global_shape[self.axis] // cells_front)}")
-                self._send(self.base_comm, self.base_comm_nccl,
-                           send_buf, dest=self.rank + 1, tag=1,
-                           engine=self.engine)
+                    raise ValueError(
+                        f"Local Shape at rank={self.rank} along axis={self.axis} "
+                        f"should be > {cells_front}: dim({self.axis}) "
+                        f"{self.local_shape[self.axis]} < {cells_front}; "
+                        f"to achieve this use NUM_PROCESSES <= "
+                        f"{max(1, self.global_shape[self.axis] // cells_front)}"
+                    )
+                self._send(
+                    self.base_comm,
+                    self.base_comm_nccl,
+                    send_buf,
+                    dest=self.rank + 1,
+                    tag=1,
+                    engine=self.engine,
+                )
         if cells_back is not None:
             total_cells_back = self.base_comm.allgather(cells_back) + [0]
             # Read cells_back which needs to be sent to rank - 1(cells_back for rank - 1)
             cells_back = total_cells_back[self.rank - 1]
-            send_buf = ncp.take(self.local_array, ncp.arange(cells_back), axis=self.axis)
+            send_buf = ncp.take(
+                self.local_array, ncp.arange(cells_back), axis=self.axis
+            )
             # Same reasoning as sending cell front applied
             recv_shapes = self.local_shapes
             if self.rank != 0 and len(send_buf) != 0:
                 if cells_back > self.local_shape[self.axis]:
-                    raise ValueError(f"Local Shape at rank={self.rank} along axis={self.axis} "
-                                     f"should be > {cells_back}: dim({self.axis}) "
-                                     f"{self.local_shape[self.axis]} < {cells_back}; "
-                                     f"to achieve this use NUM_PROCESSES <= "
-                                     f"{max(1, self.global_shape[self.axis] // cells_back)}")
-                self._send(self.base_comm, self.base_comm_nccl,
-                           send_buf, dest=self.rank - 1, tag=0,
-                           engine=self.engine)
+                    raise ValueError(
+                        f"Local Shape at rank={self.rank} along axis={self.axis} "
+                        f"should be > {cells_back}: dim({self.axis}) "
+                        f"{self.local_shape[self.axis]} < {cells_back}; "
+                        f"to achieve this use NUM_PROCESSES <= "
+                        f"{max(1, self.global_shape[self.axis] // cells_back)}"
+                    )
+                self._send(
+                    self.base_comm,
+                    self.base_comm_nccl,
+                    send_buf,
+                    dest=self.rank - 1,
+                    tag=0,
+                    engine=self.engine,
+                )
             if self.rank != self.size - 1:
                 recv_shape = list(recv_shapes[self.rank + 1])
                 recv_shape[self.axis] = total_cells_back[self.rank]
                 recv_buf = ncp.zeros(recv_shape, dtype=ghosted_array.dtype)
                 if len(recv_buf) != 0:
-                    ghosted_array = ncp.append(ghosted_array, self._recv(self.base_comm, self.base_comm_nccl,
-                                                                         recv_buf, source=self.rank + 1, tag=0,
-                                                                         engine=self.engine),
-                                               axis=self.axis)
+                    ghosted_array = ncp.append(
+                        ghosted_array,
+                        self._recv(
+                            self.base_comm,
+                            self.base_comm_nccl,
+                            recv_buf,
+                            source=self.rank + 1,
+                            tag=0,
+                            engine=self.engine,
+                        ),
+                        axis=self.axis,
+                    )
         return ghosted_array
 
     def __repr__(self):
-        return f"<DistributedArray with global shape={self.global_shape}, " \
-               f"local shape={self.local_shape}" \
-               f", dtype={self.dtype}, " \
-               f"processes={[i for i in range(self.size)]})> "
+        return (
+            f"<DistributedArray with global shape={self.global_shape}, "
+            f"local shape={self.local_shape}"
+            f", dtype={self.dtype}, "
+            f"processes={[i for i in range(self.size)]})> "
+        )
 
 
 class StackedDistributedArray:
@@ -1077,13 +1310,19 @@ class StackedDistributedArray:
         # Define global shape as sum as shapes
         self._global_shape = distarrays[0].global_shape
         for iarr in range(1, self.narrays):
-            self._global_shape = \
-                tuple([g1 + g2 for g1, g2 in
-                       zip(self._global_shape, distarrays[iarr].global_shape)])
+            self._global_shape = tuple(
+                [
+                    g1 + g2
+                    for g1, g2 in zip(self._global_shape, distarrays[iarr].global_shape)
+                ]
+            )
 
     def __repr__(self) -> str:
         repr_dist = "\n".join([distarray.__repr__() for distarray in self.distarrays])
-        return f"<StackedDistributedArray with {self.narrays} distributed arrays: \n" + repr_dist
+        return (
+            f"<StackedDistributedArray with {self.narrays} distributed arrays: \n"
+            + repr_dist
+        )
 
     def __getitem__(self, index):
         return self.distarrays[index]
@@ -1144,16 +1383,18 @@ class StackedDistributedArray:
         return ncp.hstack([distarr.asarray().ravel() for distarr in self.distarrays])
 
     def _check_stacked_size(self, stacked_array: Self) -> None:
-        """Check that arrays have consistent size
-
-        """
+        """Check that arrays have consistent size"""
         if self.narrays != stacked_array.narrays:
-            raise ValueError("Stacked arrays must be composed the same number of of distributed arrays")
+            raise ValueError(
+                "Stacked arrays must be composed the same number of of distributed arrays"
+            )
         for iarr in range(self.narrays):
             if self.distarrays[iarr].global_shape != stacked_array[iarr].global_shape:
-                raise ValueError(f"Stacked arrays {iarr} have different global shape:"
-                                 f"{self.distarrays[iarr].global_shape} / "
-                                 f"{stacked_array[iarr].global_shape}")
+                raise ValueError(
+                    f"Stacked arrays {iarr} have different global shape:"
+                    f"{self.distarrays[iarr].global_shape} / "
+                    f"{stacked_array[iarr].global_shape}"
+                )
 
     def __neg__(self):
         arr = self.copy()
@@ -1183,31 +1424,28 @@ class StackedDistributedArray:
         return self.multiply(x)
 
     def add(self, stacked_array: Self) -> Self:
-        """Stacked Distributed Addition of arrays
-        """
+        """Stacked Distributed Addition of arrays"""
         self._check_stacked_size(stacked_array)
         SumArray = self.copy()
         for iarr in range(self.narrays):
             if isinstance(stacked_array[iarr], StackedDistributedArray):
-                SumArray[iarr] = (self[iarr] + stacked_array[iarr])
+                SumArray[iarr] = self[iarr] + stacked_array[iarr]
             else:
                 SumArray[iarr][:] = (self[iarr] + stacked_array[iarr])[:]
         return SumArray
 
     def iadd(self, stacked_array: Self) -> Self:
-        """Stacked Distributed In-Place Addition of arrays
-        """
+        """Stacked Distributed In-Place Addition of arrays"""
         self._check_stacked_size(stacked_array)
         for iarr in range(self.narrays):
             if isinstance(self[iarr], StackedDistributedArray):
-                self[iarr] = (self[iarr] + stacked_array[iarr])
+                self[iarr] = self[iarr] + stacked_array[iarr]
             else:
                 self[iarr][:] = (self[iarr] + stacked_array[iarr])[:]
         return self
 
     def multiply(self, stacked_array: float | int | Self) -> Self:
-        """Stacked Distributed Multiplication of arrays
-        """
+        """Stacked Distributed Multiplication of arrays"""
         if isinstance(stacked_array, StackedDistributedArray):
             self._check_stacked_size(stacked_array)
         ProductArray = self.copy()
@@ -1216,14 +1454,14 @@ class StackedDistributedArray:
             # multiply two StackedDistributedArray
             for iarr in range(self.narrays):
                 if isinstance(self[iarr], StackedDistributedArray):
-                    ProductArray[iarr] = (self[iarr] * stacked_array[iarr])
+                    ProductArray[iarr] = self[iarr] * stacked_array[iarr]
                 else:
                     ProductArray[iarr][:] = (self[iarr] * stacked_array[iarr])[:]
         else:
             # multiply with scalar
             for iarr in range(self.narrays):
                 if isinstance(self[iarr], StackedDistributedArray):
-                    ProductArray[iarr] = (self[iarr] * stacked_array)
+                    ProductArray[iarr] = self[iarr] * stacked_array
                 else:
                     ProductArray[iarr][:] = (self[iarr] * stacked_array)[:]
         return ProductArray
@@ -1245,76 +1483,97 @@ class StackedDistributedArray:
 
         Returns
         -------
-        result : float
+        result : :obj:`float` or :obj:`complex`
             The result of the dot product across all ranks. This is reduced across all processes.
         """
         self._check_stacked_size(stacked_array)
-        dotprod = 0.
+        dotprod = 0.0
         for iarr in range(self.narrays):
             dotprod += self[iarr].dot(stacked_array[iarr], vdot=vdot)
         return dotprod
 
-    def norm(self, ord: Optional[int] = None) -> bool | float:
+    def norm(self, ord: Optional[int] = None) -> float:
         """numpy.linalg.norm method on stacked Distributed arrays
 
         Parameters
         ----------
         ord : :obj:`int`, optional
             Order of the norm.
+
+        Returns
+        -------
+        norm : :obj:`float`
+            The computed norm of the stacked distributed array.
         """
-        ncp = get_module(self.engine)
-        norms = ncp.hstack([distarray.norm(ord) for distarray in self.distarrays])
+        # Note that the norms of the individual distributed arrays are
+        # scalars (irrespective of the engine used), thus numpy is used
+        # to combine them
+        norms = np.array([distarray.norm(ord) for distarray in self.distarrays])
         ord = 2 if ord is None else ord
-        if ord in ['fro', 'nuc']:
+        if ord in ["fro", "nuc"]:
             raise ValueError(f"norm-{ord} not possible for vectors")
         elif ord == 0:
             # Count non-zero then sum reduction
-            norm = ncp.sum(norms)
-        elif ord == ncp.inf:
+            norm = np.sum(norms)
+        elif ord == np.inf:
             # Calculate max followed by max reduction
-            norm = ncp.max(norms)
-        elif ord == -ncp.inf:
+            norm = np.max(norms)
+        elif ord == -np.inf:
             # Calculate min followed by max reduction
-            norm = ncp.min(norms)
+            norm = np.min(norms)
         else:
-            norm = ncp.power(ncp.sum(ncp.power(norms, ord)), 1. / ord)
-        return norm
+            norm = np.power(np.sum(np.power(norms, ord)), 1.0 / ord)
+        return to_scalar(norm)
 
     def conj(self) -> Self:
-        """Distributed conj() method
-        """
-        ConjArray = StackedDistributedArray([distarray.conj() for distarray in self.distarrays])
+        """Distributed conj() method"""
+        ConjArray = StackedDistributedArray(
+            [distarray.conj() for distarray in self.distarrays]
+        )
         return ConjArray
 
     def copy(self) -> Self:
-        """Creates a copy of the DistributedArray
-        """
-        arr = StackedDistributedArray([distarray.copy() for distarray in self.distarrays])
+        """Creates a copy of the DistributedArray"""
+        arr = StackedDistributedArray(
+            [distarray.copy() for distarray in self.distarrays]
+        )
         return arr
 
     def zeros_like(self) -> Self:
-        """Creates a zero like StackedDistributedArray
-        """
+        """Creates a zero like StackedDistributedArray"""
         dists = []
         for iarr in range(self.narrays):
             distarray = self.distarrays[iarr]
-            dist = DistributedArray(global_shape=distarray.global_shape, base_comm=distarray.base_comm,
-                                    base_comm_nccl=distarray.base_comm_nccl, partition=distarray.partition,
-                                    axis=distarray.axis, local_shapes=distarray.local_shapes, mask=distarray.mask,
-                                    engine=distarray.engine, dtype=distarray.dtype)
-            dist[:] = 0.
+            dist = DistributedArray(
+                global_shape=distarray.global_shape,
+                base_comm=distarray.base_comm,
+                base_comm_nccl=distarray.base_comm_nccl,
+                partition=distarray.partition,
+                axis=distarray.axis,
+                local_shapes=distarray.local_shapes,
+                mask=distarray.mask,
+                engine=distarray.engine,
+                dtype=distarray.dtype,
+            )
+            dist[:] = 0.0
             dists.append(dist)
         return StackedDistributedArray(distarrays=dists)
 
     def empty_like(self) -> Self:
-        """Creates an empty like StackedDistributedArray with uninitialized values
-        """
+        """Creates an empty like StackedDistributedArray with uninitialized values"""
         dists = []
         for iarr in range(self.narrays):
             distarray = self.distarrays[iarr]
-            dist = DistributedArray(global_shape=distarray.global_shape, base_comm=distarray.base_comm,
-                                    base_comm_nccl=distarray.base_comm_nccl, partition=distarray.partition,
-                                    axis=distarray.axis, local_shapes=distarray.local_shapes, mask=distarray.mask,
-                                    engine=distarray.engine, dtype=distarray.dtype)
+            dist = DistributedArray(
+                global_shape=distarray.global_shape,
+                base_comm=distarray.base_comm,
+                base_comm_nccl=distarray.base_comm_nccl,
+                partition=distarray.partition,
+                axis=distarray.axis,
+                local_shapes=distarray.local_shapes,
+                mask=distarray.mask,
+                engine=distarray.engine,
+                dtype=distarray.dtype,
+            )
             dists.append(dist)
         return StackedDistributedArray(distarrays=dists)

--- a/pylops_mpi/optimization/cls_basic.py
+++ b/pylops_mpi/optimization/cls_basic.py
@@ -1,8 +1,8 @@
-from typing import List, Optional, Tuple, Union
 import sys
 import time
-import numpy as np
+from typing import List, Optional, Tuple, Union
 
+import numpy as np
 from pylops.optimization.basesolver import Solver
 from pylops.utils import NDArray
 
@@ -46,7 +46,11 @@ class CG(Solver):
     def _print_step(self, x: Union[DistributedArray, StackedDistributedArray]) -> None:
         if isinstance(x, StackedDistributedArray):
             x = x.distarrays[0]
-        strx = f"{x[0]:1.2e}        " if np.iscomplexobj(x.local_array) else f"{x[0]:11.4e}        "
+        strx = (
+            f"{x[0]:1.2e}        "
+            if np.iscomplexobj(x.local_array)
+            else f"{x[0]:11.4e}        "
+        )
         msg = f"{self.iiter:6g}        " + strx + f"{self.cost[self.iiter]:11.4e}"
         print(msg)
         sys.stdout.flush()
@@ -55,12 +59,12 @@ class CG(Solver):
         pass
 
     def setup(
-            self,
-            y: Union[DistributedArray, StackedDistributedArray],
-            x0: Union[DistributedArray, StackedDistributedArray],
-            niter: Optional[int] = None,
-            tol: float = 1e-4,
-            show: bool = False,
+        self,
+        y: Union[DistributedArray, StackedDistributedArray],
+        x0: Union[DistributedArray, StackedDistributedArray],
+        niter: Optional[int] = None,
+        tol: float = 1e-4,
+        show: bool = False,
     ) -> Union[DistributedArray, StackedDistributedArray]:
         r"""Setup solver
 
@@ -92,7 +96,7 @@ class CG(Solver):
         self.r = self.y - self.Op.matvec(x)
         self.rank = x.rank
         self.c = self.r.copy()
-        self.kold = float(np.abs(self.r.dot(self.r.conj())).item())
+        self.kold = float(np.abs(self.r.dot(self.r.conj())))
 
         # create variables to track the residual norm and iterations
         self.cost: List = []
@@ -107,9 +111,9 @@ class CG(Solver):
                 self._print_setup(np.iscomplexobj(x.local_array))
         return x
 
-    def step(self, x: Union[DistributedArray, StackedDistributedArray],
-             show: bool = False
-             ) -> Union[DistributedArray, StackedDistributedArray]:
+    def step(
+        self, x: Union[DistributedArray, StackedDistributedArray], show: bool = False
+    ) -> Union[DistributedArray, StackedDistributedArray]:
         r"""Run one step of solver
 
         Parameters
@@ -127,10 +131,10 @@ class CG(Solver):
         """
         Opc = self.Op.matvec(self.c)
         cOpc = np.abs(self.c.dot(Opc.conj()))
-        a = float((self.kold / cOpc).item())
+        a = float(self.kold / cOpc)
         x += a * self.c
         self.r -= a * Opc
-        k = float(np.abs(self.r.dot(self.r.conj())).item())
+        k = float(np.abs(self.r.dot(self.r.conj())))
         b = float(k / self.kold)
         self.c = self.r + b * self.c
         self.kold = k
@@ -141,11 +145,11 @@ class CG(Solver):
         return x
 
     def run(
-            self,
-            x: Union[DistributedArray, StackedDistributedArray],
-            niter: Optional[int] = None,
-            show: bool = False,
-            itershow: Tuple[int, int, int] = (10, 10, 10),
+        self,
+        x: Union[DistributedArray, StackedDistributedArray],
+        niter: Optional[int] = None,
+        show: bool = False,
+        itershow: Tuple[int, int, int] = (10, 10, 10),
     ) -> Union[DistributedArray, StackedDistributedArray]:
         r"""Run solver
 
@@ -205,13 +209,13 @@ class CG(Solver):
             self._print_finalize(nbar=55)
 
     def solve(
-            self,
-            y: Union[DistributedArray, StackedDistributedArray],
-            x0: Union[DistributedArray, StackedDistributedArray],
-            niter: int = 10,
-            tol: float = 1e-4,
-            show: bool = False,
-            itershow: Tuple[int, int, int] = (10, 10, 10),
+        self,
+        y: Union[DistributedArray, StackedDistributedArray],
+        x0: Union[DistributedArray, StackedDistributedArray],
+        niter: int = 10,
+        tol: float = 1e-4,
+        show: bool = False,
+        itershow: Tuple[int, int, int] = (10, 10, 10),
     ) -> Tuple[Union[DistributedArray, StackedDistributedArray], int, NDArray]:
         r"""Run entire solver
 
@@ -293,7 +297,11 @@ class CGLS(Solver):
     def _print_step(self, x: Union[DistributedArray, StackedDistributedArray]) -> None:
         if isinstance(x, StackedDistributedArray):
             x = x.distarrays[0]
-        strx = f"{x[0]:1.2e}   " if np.iscomplexobj(x.local_array) else f"{x[0]:11.4e}        "
+        strx = (
+            f"{x[0]:1.2e}   "
+            if np.iscomplexobj(x.local_array)
+            else f"{x[0]:11.4e}        "
+        )
         msg = (
             f"{self.iiter:6g}       "
             + strx
@@ -305,14 +313,15 @@ class CGLS(Solver):
     def memory_usage(self) -> None:
         pass
 
-    def setup(self,
-              y: Union[DistributedArray, StackedDistributedArray],
-              x0: Union[DistributedArray, StackedDistributedArray],
-              niter: Optional[int] = None,
-              damp: float = 0.0,
-              tol: float = 1e-4,
-              show: bool = False,
-              ) -> Union[DistributedArray, StackedDistributedArray]:
+    def setup(
+        self,
+        y: Union[DistributedArray, StackedDistributedArray],
+        x0: Union[DistributedArray, StackedDistributedArray],
+        niter: Optional[int] = None,
+        damp: float = 0.0,
+        tol: float = 1e-4,
+        show: bool = False,
+    ) -> Union[DistributedArray, StackedDistributedArray]:
         r"""Setup solver
 
         Parameters
@@ -338,7 +347,7 @@ class CGLS(Solver):
 
         """
         self.y = y
-        self.damp = damp ** 2
+        self.damp = damp**2
         self.tol = tol
         self.niter = niter
 
@@ -349,13 +358,15 @@ class CGLS(Solver):
         self.rank = x.rank
         self.c = r.copy()
         self.q = self.Op.matvec(self.c)
-        self.kold = float(np.abs(r.dot(r.conj())).item())
+        self.kold = float(np.abs(r.dot(r.conj())))
 
         # create variables to track the residual norm and iterations
         self.cost = []
         self.cost1 = []
-        self.cost.append(float(self.s.norm().item()))
-        self.cost1.append(np.sqrt(float(self.cost[0] ** 2 + damp * np.abs(x.dot(x.conj())).item())))
+        self.cost.append(float(self.s.norm()))
+        self.cost1.append(
+            np.sqrt(float(self.cost[0] ** 2 + damp * np.abs(x.dot(x.conj()))))
+        )
         self.iiter = 0
 
         # print setup
@@ -367,9 +378,9 @@ class CGLS(Solver):
                 self._print_setup(np.iscomplexobj(x.local_array))
         return x
 
-    def step(self, x: Union[DistributedArray, StackedDistributedArray],
-             show: bool = False
-             ) -> Union[DistributedArray, StackedDistributedArray]:
+    def step(
+        self, x: Union[DistributedArray, StackedDistributedArray], show: bool = False
+    ) -> Union[DistributedArray, StackedDistributedArray]:
         r"""Run one step of solver
 
         Parameters
@@ -386,28 +397,39 @@ class CGLS(Solver):
 
         """
 
-        a = float(np.abs(self.kold / (self.q.dot(self.q.conj()) + self.damp * self.c.dot(self.c.conj()))).item())
+        a = float(
+            np.abs(
+                self.kold
+                / (self.q.dot(self.q.conj()) + self.damp * self.c.dot(self.c.conj()))
+            )
+        )
         x += a * self.c
         self.s -= a * self.q
         damped_x = self.damp * x
         r = self.Op.rmatvec(self.s) - damped_x
-        k = float(np.abs(r.dot(r.conj())).item())
+        k = float(np.abs(r.dot(r.conj())))
         b = float(k / self.kold)
         self.c = r + b * self.c
         self.q = self.Op.matvec(self.c)
         self.kold = k
         self.iiter += 1
-        self.cost.append(float(self.s.norm().item()))
-        self.cost1.append(np.sqrt(float(self.cost[self.iiter] ** 2 + self.damp * np.abs(x.dot(x.conj())).item())))
+        self.cost.append(float(self.s.norm()))
+        self.cost1.append(
+            np.sqrt(
+                float(self.cost[self.iiter] ** 2 + self.damp * np.abs(x.dot(x.conj())))
+            )
+        )
         if show and self.rank == 0:
             self._print_step(x)
         return x
 
-    def run(self,
-            x: Union[DistributedArray, StackedDistributedArray],
-            niter: Optional[int] = None,
-            show: bool = False,
-            itershow: Tuple[int, int, int] = (10, 10, 10), ) -> Union[DistributedArray, StackedDistributedArray]:
+    def run(
+        self,
+        x: Union[DistributedArray, StackedDistributedArray],
+        niter: Optional[int] = None,
+        show: bool = False,
+        itershow: Tuple[int, int, int] = (10, 10, 10),
+    ) -> Union[DistributedArray, StackedDistributedArray]:
         r"""Run solver
 
         Parameters
@@ -468,15 +490,16 @@ class CGLS(Solver):
             self._print_finalize(nbar=65)
         self.cost = np.array(self.cost)
 
-    def solve(self,
-              y: Union[DistributedArray, StackedDistributedArray],
-              x0: Union[DistributedArray, StackedDistributedArray],
-              niter: int = 10,
-              damp: float = 0.0,
-              tol: float = 1e-4,
-              show: bool = False,
-              itershow: Tuple[int, int, int] = (10, 10, 10),
-              ) -> Tuple[DistributedArray, int, int, float, float, NDArray]:
+    def solve(
+        self,
+        y: Union[DistributedArray, StackedDistributedArray],
+        x0: Union[DistributedArray, StackedDistributedArray],
+        niter: int = 10,
+        damp: float = 0.0,
+        tol: float = 1e-4,
+        show: bool = False,
+        itershow: Tuple[int, int, int] = (10, 10, 10),
+    ) -> Tuple[DistributedArray, int, int, float, float, NDArray]:
         r"""Run entire solver
 
         Parameters

--- a/pylops_mpi/optimization/cls_sparsity.py
+++ b/pylops_mpi/optimization/cls_sparsity.py
@@ -1,25 +1,32 @@
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+import logging
 import sys
 import time
-import logging
 from math import sqrt
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import numpy as np
-
 from pylops.optimization.basesolver import Solver
-from pylops.optimization.cls_sparsity import _halfthreshold, _hardthreshold, _softthreshold
+from pylops.optimization.cls_sparsity import (
+    _halfthreshold,
+    _hardthreshold,
+    _softthreshold,
+)
 from pylops.utils import get_array_module, get_module_name, get_real_dtype
 from pylops.utils.typing import NDArray
 
 from pylops_mpi.DistributedArray import DistributedArray, StackedDistributedArray
 from pylops_mpi.LinearOperator import MPILinearOperator
-from pylops_mpi.StackedLinearOperator import MPIStackedLinearOperator
 from pylops_mpi.optimization.eigs import power_iteration
+from pylops_mpi.StackedLinearOperator import MPIStackedLinearOperator
 
 logger = logging.getLogger(__name__)
 
 
-def _apply_thresh(x: Union[DistributedArray, StackedDistributedArray], threshf: Callable, thresh: float):
+def _apply_thresh(
+    x: Union[DistributedArray, StackedDistributedArray],
+    threshf: Callable,
+    thresh: float,
+):
     """Apply thresholding
 
     Apply a thresholding function to a distributed array or stacked distributed array.
@@ -114,16 +121,18 @@ class ISTA(Solver):
         sys.stdout.flush()
 
     def _print_step(
-            self,
-            x: Union[DistributedArray, StackedDistributedArray],
-            costdata: float,
-            costreg: float,
-            xupdate: float,
+        self,
+        x: Union[DistributedArray, StackedDistributedArray],
+        costdata: float,
+        costreg: float,
+        xupdate: float,
     ) -> None:
         if isinstance(x, StackedDistributedArray):
             x = x.distarrays[0]
         strx = (
-            f"  {x[0]:1.2e}   " if np.iscomplexobj(x.local_array) else f"     {x[0]:11.4e}        "
+            f"  {x[0]:1.2e}   "
+            if np.iscomplexobj(x.local_array)
+            else f"     {x[0]:11.4e}        "
         )
         msg = (
             f"{self.iiter:6g} "
@@ -134,26 +143,26 @@ class ISTA(Solver):
         sys.stdout.flush()
 
     def memory_usage(
-            self,
-            show: bool = False,
-            unit: str = "B",
+        self,
+        show: bool = False,
+        unit: str = "B",
     ) -> float:
         pass
 
     def setup(
-            self,
-            y: Union[DistributedArray, StackedDistributedArray],
-            x0: Union[DistributedArray, StackedDistributedArray],
-            niter: Optional[int] = None,
-            SOp: Optional[Union[MPILinearOperator, MPIStackedLinearOperator]] = None,
-            eps: float = 0.1,
-            alpha: Optional[float] = None,
-            eigsdict: Optional[Dict[str, Any]] = None,
-            tol: float = 1e-10,
-            threshkind: str = "soft",
-            decay: Optional[NDArray] = None,
-            monitorres: bool = False,
-            show: bool = False,
+        self,
+        y: Union[DistributedArray, StackedDistributedArray],
+        x0: Union[DistributedArray, StackedDistributedArray],
+        niter: Optional[int] = None,
+        SOp: Optional[Union[MPILinearOperator, MPIStackedLinearOperator]] = None,
+        eps: float = 0.1,
+        alpha: Optional[float] = None,
+        eigsdict: Optional[Dict[str, Any]] = None,
+        tol: float = 1e-10,
+        threshkind: str = "soft",
+        decay: Optional[NDArray] = None,
+        monitorres: bool = False,
+        show: bool = False,
     ) -> DistributedArray:
         r"""Setup solver
 
@@ -223,9 +232,7 @@ class ISTA(Solver):
             "soft",
             "half",
         ]:
-            raise ValueError(
-                f"threshkind must be hard, soft, half, got {threshkind}"
-            )
+            raise ValueError(f"threshkind must be hard, soft, half, got {threshkind}")
 
         self.threshf: Callable[[DistributedArray, float], DistributedArray]
         if threshkind == "soft":
@@ -250,7 +257,7 @@ class ISTA(Solver):
                     b_k=x0.empty_like(),
                     dtype=Op1.dtype,
                     backend=get_module_name(self.ncp),
-                    **self.eigsdict
+                    **self.eigsdict,
                 )[0]
             )
             self.alpha = float(1.0 / maxeig)
@@ -271,9 +278,7 @@ class ISTA(Solver):
         return x
 
     def step(
-            self,
-            x: Union[DistributedArray, StackedDistributedArray],
-            show: bool = False
+        self, x: Union[DistributedArray, StackedDistributedArray], show: bool = False
     ) -> (Tuple)[Union[DistributedArray, StackedDistributedArray], float]:
         r"""Run one step of solver
 
@@ -326,7 +331,8 @@ class ISTA(Solver):
             x_unthesh_or_SOpx_unthesh = SOpx_unthesh
 
         x = _apply_thresh(
-            x_unthesh_or_SOpx_unthesh, self.threshf,
+            x_unthesh_or_SOpx_unthesh,
+            self.threshf,
             self.decay[self.iiter] * self.thresh,
         )
 
@@ -335,10 +341,10 @@ class ISTA(Solver):
             x = self.SOpmatvec(x)
 
         # compute model update norm
-        xupdate = (x - xold).norm().item()
+        xupdate = (x - xold).norm()
 
-        costdata = 0.5 * res.norm().item() ** 2
-        costreg = self.eps * x.norm(ord=1).item()
+        costdata = 0.5 * res.norm() ** 2
+        costreg = self.eps * x.norm(ord=1)
         self.cost.append(float(costdata + costreg))
         self.iiter += 1
         if show and self.rank == 0:
@@ -346,11 +352,11 @@ class ISTA(Solver):
         return x, xupdate
 
     def run(
-            self,
-            x: Union[DistributedArray, StackedDistributedArray],
-            niter: Optional[int] = None,
-            show: bool = False,
-            itershow: Tuple[int, int, int] = (10, 10, 10),
+        self,
+        x: Union[DistributedArray, StackedDistributedArray],
+        niter: Optional[int] = None,
+        show: bool = False,
+        itershow: Tuple[int, int, int] = (10, 10, 10),
     ) -> Union[DistributedArray, StackedDistributedArray]:
         r"""Run solver
 
@@ -382,7 +388,8 @@ class ISTA(Solver):
         while self.iiter < niter and xupdate > self.tol:
             showstep = (
                 True
-                if show and (
+                if show
+                and (
                     self.iiter < itershow[0]
                     or niter - self.iiter < itershow[1]
                     or self.iiter % itershow[2] == 0
@@ -411,20 +418,20 @@ class ISTA(Solver):
             self._print_finalize()
 
     def solve(
-            self,
-            y: Union[DistributedArray, StackedDistributedArray],
-            x0: Union[DistributedArray, StackedDistributedArray],
-            niter: Optional[int] = None,
-            SOp: Optional[MPILinearOperator] = None,
-            eps: float = 0.1,
-            alpha: Optional[float] = None,
-            eigsdict: Optional[Dict[str, Any]] = None,
-            tol: float = 1e-10,
-            threshkind: str = "soft",
-            decay: Optional[DistributedArray] = None,
-            monitorres: bool = False,
-            show: bool = False,
-            itershow: Tuple[int, int, int] = (10, 10, 10),
+        self,
+        y: Union[DistributedArray, StackedDistributedArray],
+        x0: Union[DistributedArray, StackedDistributedArray],
+        niter: Optional[int] = None,
+        SOp: Optional[MPILinearOperator] = None,
+        eps: float = 0.1,
+        alpha: Optional[float] = None,
+        eigsdict: Optional[Dict[str, Any]] = None,
+        tol: float = 1e-10,
+        threshkind: str = "soft",
+        decay: Optional[DistributedArray] = None,
+        monitorres: bool = False,
+        show: bool = False,
+        itershow: Tuple[int, int, int] = (10, 10, 10),
     ) -> Tuple[Union[DistributedArray, StackedDistributedArray], int, NDArray]:
         r"""
         Parameters
@@ -582,8 +589,12 @@ class FISTA(ISTA):
         self,
         x: Union[DistributedArray, StackedDistributedArray],
         z: Union[DistributedArray, StackedDistributedArray],
-        show: bool = False
-    ) -> Tuple[Union[DistributedArray, StackedDistributedArray], Union[DistributedArray, StackedDistributedArray], float]:
+        show: bool = False,
+    ) -> Tuple[
+        Union[DistributedArray, StackedDistributedArray],
+        Union[DistributedArray, StackedDistributedArray],
+        float,
+    ]:
         r"""Run one step of solver
 
         Parameters
@@ -636,7 +647,8 @@ class FISTA(ISTA):
         else:
             x_unthesh_or_SOpx_unthesh = SOpx_unthesh
         x = _apply_thresh(
-            x_unthesh_or_SOpx_unthesh, self.threshf,
+            x_unthesh_or_SOpx_unthesh,
+            self.threshf,
             self.decay[self.iiter] * self.thresh,
         )
 
@@ -652,11 +664,11 @@ class FISTA(ISTA):
         z = x + ((told - 1.0) / self.t) * (x - xold)
 
         # check model update
-        xupdate = (x - xold).norm().item()
+        xupdate = (x - xold).norm()
 
         # cost functions
-        costdata = 0.5 * (self.y - self.Op @ x).norm().item() ** 2
-        costreg = self.eps * x.norm(ord=1).item()
+        costdata = 0.5 * (self.y - self.Op @ x).norm() ** 2
+        costreg = self.eps * x.norm(ord=1)
         self.cost.append(float(costdata + costreg))
 
         self.iiter += 1

--- a/pylops_mpi/optimization/eigs.py
+++ b/pylops_mpi/optimization/eigs.py
@@ -8,12 +8,12 @@ from pylops_mpi.StackedLinearOperator import MPIStackedLinearOperator
 
 
 def power_iteration(
-        Op: Union[MPILinearOperator, MPIStackedLinearOperator],
-        b_k: Union[DistributedArray, StackedDistributedArray],
-        niter: int = 10,
-        tol: float = 1e-5,
-        dtype: str = "float64",
-        backend: str = "numpy",
+    Op: Union[MPILinearOperator, MPIStackedLinearOperator],
+    b_k: Union[DistributedArray, StackedDistributedArray],
+    niter: int = 10,
+    tol: float = 1e-5,
+    dtype: str = "float64",
+    backend: str = "numpy",
 ) -> Tuple[float, DistributedArray, int]:
     """Power iteration algorithm.
 
@@ -62,15 +62,13 @@ def power_iteration(
     if isinstance(b_k, StackedDistributedArray):
         for iarr in range(b_k.narrays):
             dist = b_k[iarr]
-            b_k[iarr][:] = (
-                ncp.random.rand(dist.local_shape[0]).astype(dtype)
-                + cmpx * ncp.random.rand(dist.local_shape[0]).astype(dtype)
-            )
+            b_k[iarr][:] = ncp.random.rand(dist.local_shape[0]).astype(
+                dtype
+            ) + cmpx * ncp.random.rand(dist.local_shape[0]).astype(dtype)
     else:
-        b_k[:] = (
-            ncp.random.rand(b_k.local_shape[0]).astype(dtype)
-            + cmpx * ncp.random.rand(b_k.local_shape[0]).astype(dtype)
-        )
+        b_k[:] = ncp.random.rand(b_k.local_shape[0]).astype(
+            dtype
+        ) + cmpx * ncp.random.rand(b_k.local_shape[0]).astype(dtype)
     b_k_norm = b_k.norm()
     if isinstance(b_k, StackedDistributedArray):
         for iarr in range(b_k.narrays):
@@ -83,7 +81,7 @@ def power_iteration(
         b1_k = Op.matvec(b_k)
 
         # Compute largest eigenvalue
-        maxeig = b_k.dot(b1_k, vdot=True).item()
+        maxeig = b_k.dot(b1_k, vdot=True)
         b1_k_norm = b1_k.norm()
 
         # Renormalize the vector

--- a/pylops_mpi/proximal/optimization/primal.py
+++ b/pylops_mpi/proximal/optimization/primal.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from pylops.utils.backend import to_numpy
 from pylops.utils.typing import NDArray
-
 from pyproximal.optimization.primal import _x0z0_init
 
 from pylops_mpi import DistributedArray, StackedDistributedArray
@@ -53,7 +52,7 @@ def ProximalGradient(
         Proximal operator of f function (must have ``grad`` implemented)
     proxg : :obj:`pylops_mpi.proximal.MPIProxOperator`
         Proximal operator of g function
-    x0 : :obj:`pylops_mpi.DistributedArray` or :obj:`pylops_mpi.StackedDistributedArray`
+    x0 : :obj:`pylops_mpi.DistributedArray`
         Initial vector
     epsg : :obj:`float` or :obj:`numpy.ndarray`, optional
         Scaling factor of g function. Can be a scalar
@@ -83,7 +82,7 @@ def ProximalGradient(
 
     Returns
     -------
-    x : :obj:`pylops_mpi.DistributedArray` or :obj:`pylops_mpi.StackedDistributedArray`
+    x : :obj:`pylops_mpi.DistributedArray`
         Inverted model
 
     Notes
@@ -145,9 +144,7 @@ def ProximalGradient(
         if eta == 1.0:
             x = proxg.prox(y - tau * proxf.grad(y), epsg[iiter] * tau)
         else:
-            x = x + eta * (
-                proxg.prox(x - tau * proxf.grad(x), epsg[iiter] * tau) - x
-            )
+            x = x + eta * (proxg.prox(x - tau * proxf.grad(x), epsg[iiter] * tau) - x)
 
         # update y
         if acceleration == "vandenberghe":
@@ -239,18 +236,18 @@ def ADMML2(
         Proximal operator of g function
     Op : :obj:`pylops_mpi.MPILinearOperator` or :obj:`pylops_mpi.MPIStackedLinearOperator`
         Linear operator of data misfit term
-    b : :obj:`pylops_mpi.DistributedArray` or :obj:`pylops_mpi.StackedDistributedArray`
+    b : :obj:`pylops_mpi.DistributedArray`
         Data
     A : :obj:`pylops_mpi.MPILinearOperator` or :obj:`pylops_mpi.MPIStackedLinearOperator`
         Linear operator of regularization term
-    x0 : :obj:`pylops_mpi.DistributedArray` or :obj:`pylops_mpi.StackedDistributedArray`
+    x0 : :obj:`pylops_mpi.DistributedArray`
         Initial vector
     tau : :obj:`float`
         Positive scalar weight, which should satisfy the following condition
         to guarantees convergence: :math:`\tau \in (0, 1/\lambda_{max}(\mathbf{A}^H\mathbf{A})]`.
     niter : :obj:`int`, optional
         Number of iterations of iterative scheme
-    z0 : :obj:`pylops_mpi.DistributedArray` or :obj:`pylops_mpi.StackedDistributedArray`
+    z0 : :obj:`pylops_mpi.DistributedArray`
         Initial auxiliary vector. If ``None``, initialized to ``A @ x0``.
     gfirst : :obj:`bool`, optional
         Apply Proximal of operator ``g`` first (``True``) or Proximal of
@@ -269,9 +266,9 @@ def ADMML2(
 
     Returns
     -------
-    x : :obj:`pylops_mpi.DistributedArray` or :obj:`pylops_mpi.StackedDistributedArray`
+    x : :obj:`pylops_mpi.DistributedArray`
         Inverted model
-    z : :obj:`pylops_mpi.DistributedArray` or :obj:`pylops_mpi.StackedDistributedArray`
+    z : :obj:`pylops_mpi.DistributedArray`
         Inverted second model
 
     Raises
@@ -329,7 +326,7 @@ def ADMML2(
 
         if show:
             if iiter < 10 or niter - iiter < 10 or iiter % (niter // 10) == 0:
-                pf, pg = to_numpy(0.5 * (Op @ x - b).norm().item() ** 2), proxg(Ax)
+                pf, pg = 0.5 * (Op @ x - b).norm() ** 2, proxg(Ax)
                 if rank == 0:
                     msg = "%6g  %12.5e  %10.3e  %10.3e  %10.3e" % (
                         iiter + 1,

--- a/pylops_mpi/proximal/proximal/L2.py
+++ b/pylops_mpi/proximal/proximal/L2.py
@@ -2,11 +2,14 @@ from math import sqrt
 from typing import Any, Callable
 
 from pylops.basicoperators import Identity
-from pylops.utils.backend import to_numpy
 from pyproximal.ProxOperator import _check_tau
 
-from pylops_mpi import DistributedArray, StackedDistributedArray, Partition
-from pylops_mpi import MPILinearOperator
+from pylops_mpi import (
+    DistributedArray,
+    MPILinearOperator,
+    Partition,
+    StackedDistributedArray,
+)
 from pylops_mpi.basicoperators import MPIBlockDiag, MPIStackedVStack
 from pylops_mpi.optimization.basic import cg, cgls
 from pylops_mpi.proximal import MPIProxOperator
@@ -53,6 +56,18 @@ class MPIL2(MPIProxOperator):
     **kwargs_solver : :obj:`dict`, optional
         Dictionary containing extra arguments for the solver selected
         via the ``solver`` parameter.
+
+    Notes
+    -----
+    This is a distributed implementation of the :math:`L_{2}` norm.
+
+    The norm evaluation simply requires the evaluation of the norm of
+    the underlying distributed array.
+
+    The proximal operator in the case where ``Op`` and ``b`` are not None
+    requires the solution of a distributed inversion via the
+    :py:func:`pylops_mpi.optimization.basic.cg` or
+    :py:func:`pylops_mpi.optimization.basic.cgls` solvers.
 
     """
 
@@ -101,14 +116,10 @@ class MPIL2(MPIProxOperator):
             raise ValueError(msg)
 
         # create data term
-        if (
-            self.Op is not None
-            and self.b is not None
-            and self.normaleqs
-        ):
+        if self.Op is not None and self.b is not None and self.normaleqs:
             self.OpTb = self.sigma * self.Op.H @ self.b
 
-    def __call__(self, x: DistributedArray) -> DistributedArray:
+    def __call__(self, x: DistributedArray) -> float:
         if self.Op is not None and self.b is not None:
             f = (self.sigma / 2.0) * ((self.Op * x - self.b).norm() ** 2)
         elif self.b is not None:
@@ -117,7 +128,7 @@ class MPIL2(MPIProxOperator):
             f = (self.sigma / 2.0) * (x.norm() ** 2)
         if self.q is not None:
             f += self.alpha * self.q.dot(x)
-        return float(to_numpy(f.item()))
+        return float(f)
 
     def _increment_count(func: Callable[..., Any]) -> Callable[..., Any]:
         """Increment counter"""
@@ -131,8 +142,7 @@ class MPIL2(MPIProxOperator):
     @_increment_count
     @_check_tau
     def prox(self, x: DistributedArray, tau: float, **kwargs: Any) -> DistributedArray:
-        """Proximal operator applied to a vector
-        """
+        """Proximal operator applied to a vector"""
         # define current number of iterations
         if isinstance(self.niter, int):
             niter = self.niter
@@ -147,9 +157,21 @@ class MPIL2(MPIProxOperator):
                     y -= tau * self.alpha * self.q
             if self.normaleqs:
                 if x.partition == Partition.SCATTER:
-                    Iop = MPIBlockDiag([Identity(x.local_shape, dtype=self.Op.dtype, )])
+                    Iop = MPIBlockDiag(
+                        [
+                            Identity(
+                                x.local_shape,
+                                dtype=self.Op.dtype,
+                            )
+                        ]
+                    )
                 else:
-                    Iop = MPILinearOperator(Identity(x.local_shape, dtype=self.Op.dtype, ))
+                    Iop = MPILinearOperator(
+                        Identity(
+                            x.local_shape,
+                            dtype=self.Op.dtype,
+                        )
+                    )
                 Op1 = Iop + float(tau * self.sigma) * (self.Op.H * self.Op)
                 x = cg(Op1, y, niter=niter, x0=self.x0, **self.kwargs_solver)[0]
             else:
@@ -157,13 +179,27 @@ class MPIL2(MPIProxOperator):
                 if self.q is not None:
                     y -= tau * self.alpha * self.q
                 if x.partition == Partition.SCATTER:
-                    Iop = MPIBlockDiag([Identity(x.local_shape, dtype=self.Op.dtype, ),])
+                    Iop = MPIBlockDiag(
+                        [
+                            Identity(
+                                x.local_shape,
+                                dtype=self.Op.dtype,
+                            ),
+                        ]
+                    )
                 else:
-                    Iop = MPILinearOperator(Identity(x.local_shape, dtype=self.Op.dtype, ))
-                Opreg = MPIStackedVStack([
-                    sqrt(tau * self.sigma) * self.Op,
-                    Iop,
-                ])
+                    Iop = MPILinearOperator(
+                        Identity(
+                            x.local_shape,
+                            dtype=self.Op.dtype,
+                        )
+                    )
+                Opreg = MPIStackedVStack(
+                    [
+                        sqrt(tau * self.sigma) * self.Op,
+                        Iop,
+                    ]
+                )
                 breg = StackedDistributedArray([sqrt(tau * self.sigma) * self.b, y])
                 x = cgls(Opreg, breg, x0=self.x0, niter=niter, **self.kwargs_solver)[0]
             if self.warm:
@@ -172,7 +208,7 @@ class MPIL2(MPIProxOperator):
             num = x + tau * self.sigma * self.b
             if self.q is not None:
                 num -= tau * self.alpha * self.q
-            x = (1. / (1.0 + tau * self.sigma)) * num
+            x = (1.0 / (1.0 + tau * self.sigma)) * num
         else:
             num = x
             if self.q is not None:

--- a/tests_nccl/test_distributedarray_nccl.py
+++ b/tests_nccl/test_distributedarray_nccl.py
@@ -5,10 +5,10 @@ $ mpiexec -n 3 pytest test_distributedarray_nccl.py --with-mpi
 This file employs the same test sets as test_distributedarray under NCCL environment
 """
 
-import numpy as np
 import cupy as cp
-from mpi4py import MPI
+import numpy as np
 import pytest
+from mpi4py import MPI
 from numpy.testing import assert_allclose
 
 from pylops_mpi import DistributedArray, Partition
@@ -19,67 +19,134 @@ np.random.seed(42)
 
 nccl_comm = initialize_nccl_comm()
 
-par1 = {'global_shape': (500, 501),
-        'partition': Partition.SCATTER, 'dtype': np.float64,
-        'axis': 1}
-par1j = {'global_shape': (501, 500),
-         'partition': Partition.SCATTER, 'dtype': np.complex128,
-         'axis': 0}
-par2 = {'global_shape': (500, 501),
-        'partition': Partition.BROADCAST, 'dtype': np.float64,
-        'axis': 1}
-par2j = {'global_shape': (501, 500),
-         'partition': Partition.BROADCAST, 'dtype': np.complex128,
-         'axis': 0}
+par1 = {
+    "global_shape": (500, 501),
+    "partition": Partition.SCATTER,
+    "dtype": np.float64,
+    "axis": 1,
+}
+par1j = {
+    "global_shape": (501, 500),
+    "partition": Partition.SCATTER,
+    "dtype": np.complex128,
+    "axis": 0,
+}
+par2 = {
+    "global_shape": (500, 501),
+    "partition": Partition.BROADCAST,
+    "dtype": np.float64,
+    "axis": 1,
+}
+par2j = {
+    "global_shape": (501, 500),
+    "partition": Partition.BROADCAST,
+    "dtype": np.complex128,
+    "axis": 0,
+}
 
-par3 = {'global_shape': (200, 201, 101),
-        'partition': Partition.SCATTER,
-        'dtype': np.float64, 'axis': 1}
+par3 = {
+    "global_shape": (200, 201, 101),
+    "partition": Partition.SCATTER,
+    "dtype": np.float64,
+    "axis": 1,
+}
 
-par3j = {'global_shape': (200, 201, 101),
-         'partition': Partition.SCATTER,
-         'dtype': np.complex128, 'axis': 2}
+par3j = {
+    "global_shape": (200, 201, 101),
+    "partition": Partition.SCATTER,
+    "dtype": np.complex128,
+    "axis": 2,
+}
 
-par4 = {'x': np.random.normal(100, 100, (500, 501)),
-        'partition': Partition.SCATTER, 'axis': 1, 'norm_axis': 0}
+par4 = {
+    "x": np.random.normal(100, 100, (500, 501)),
+    "partition": Partition.SCATTER,
+    "axis": 1,
+    "norm_axis": 0,
+}
 
-par4j = {'x': np.random.normal(100, 100, (500, 501)) + 1.0j * np.random.normal(50, 50, (500, 501)),
-         'partition': Partition.SCATTER, 'axis': 1, 'norm_axis': 0}
+par4j = {
+    "x": np.random.normal(100, 100, (500, 501))
+    + 1.0j * np.random.normal(50, 50, (500, 501)),
+    "partition": Partition.SCATTER,
+    "axis": 1,
+    "norm_axis": 0,
+}
 
-par5 = {'x': np.random.normal(300, 300, (500, 501)),
-        'partition': Partition.SCATTER, 'axis': 1, 'norm_axis': 1}
+par5 = {
+    "x": np.random.normal(300, 300, (500, 501)),
+    "partition": Partition.SCATTER,
+    "axis": 1,
+    "norm_axis": 1,
+}
 
-par5j = {'x': np.random.normal(300, 300, (500, 501)) + 1.0j * np.random.normal(50, 50, (500, 501)),
-         'partition': Partition.SCATTER, 'axis': 1, 'norm_axis': 0}
+par5j = {
+    "x": np.random.normal(300, 300, (500, 501))
+    + 1.0j * np.random.normal(50, 50, (500, 501)),
+    "partition": Partition.SCATTER,
+    "axis": 1,
+    "norm_axis": 0,
+}
 
-par6 = {'x': np.random.normal(100, 100, (600, 600)),
-        'partition': Partition.SCATTER, 'axis': 0, 'norm_axis': 1}
+par6 = {
+    "x": np.random.normal(100, 100, (600, 600)),
+    "partition": Partition.SCATTER,
+    "axis": 0,
+    "norm_axis": 1,
+}
 
-par6b = {'x': np.random.normal(100, 100, (600, 600)),
-         'partition': Partition.BROADCAST, 'axis': 0, 'norm_axis': 1}
+par6b = {
+    "x": np.random.normal(100, 100, (600, 600)),
+    "partition": Partition.BROADCAST,
+    "axis": 0,
+    "norm_axis": 1,
+}
 
-par7 = {'x': np.random.normal(300, 300, (600, 600)),
-        'partition': Partition.SCATTER, 'axis': 0, 'norm_axis': 0}
+par7 = {
+    "x": np.random.normal(300, 300, (600, 600)),
+    "partition": Partition.SCATTER,
+    "axis": 0,
+    "norm_axis": 0,
+}
 
-par7b = {'x': np.random.normal(300, 300, (600, 600)),
-         'partition': Partition.BROADCAST, 'axis': 0, 'norm_axis': 0}
+par7b = {
+    "x": np.random.normal(300, 300, (600, 600)),
+    "partition": Partition.BROADCAST,
+    "axis": 0,
+    "norm_axis": 0,
+}
 
-par8 = {'x': np.random.normal(100, 100, (1200,)),
-        'partition': Partition.SCATTER, 'axis': 0, 'norm_axis': 0}
+par8 = {
+    "x": np.random.normal(100, 100, (1200,)),
+    "partition": Partition.SCATTER,
+    "axis": 0,
+    "norm_axis": 0,
+}
 
-par8b = {'x': np.random.normal(100, 100, (1200,)),
-         'partition': Partition.BROADCAST, 'axis': 0, 'norm_axis': 0}
+par8b = {
+    "x": np.random.normal(100, 100, (1200,)),
+    "partition": Partition.BROADCAST,
+    "axis": 0,
+    "norm_axis": 0,
+}
 
-par9 = {'x': np.random.normal(300, 300, (1200,)),
-        'partition': Partition.SCATTER, 'axis': 0, 'norm_axis': 0}
+par9 = {
+    "x": np.random.normal(300, 300, (1200,)),
+    "partition": Partition.SCATTER,
+    "axis": 0,
+    "norm_axis": 0,
+}
 
-par9b = {'x': np.random.normal(300, 300, (1200,)),
-         'partition': Partition.BROADCAST, 'axis': 0, 'norm_axis': 0}
+par9b = {
+    "x": np.random.normal(300, 300, (1200,)),
+    "partition": Partition.BROADCAST,
+    "axis": 0,
+    "norm_axis": 0,
+}
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par1j), (par2),
-                                 (par2j), (par3), (par3j)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j), (par3), (par3j)])
 def test_creation_nccl(par):
     """Test creation of local arrays"""
     distributed_array = DistributedArray(
@@ -162,8 +229,7 @@ def test_to_dist_nccl(par):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par1j), (par2),
-                                 (par2j), (par3), (par3j)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j), (par3), (par3j)])
 def test_local_shapes_nccl(par):
     """Test the `local_shapes` parameter in DistributedArray"""
     # Reverse the local_shapes to test the local_shapes parameter
@@ -195,9 +261,11 @@ def test_local_shapes_nccl(par):
         rtol=1e-14,
     )
 
+
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par4), (par4j), (par5), (par5j),
-                                 (par6), (par6b), (par7), (par7b)])
+@pytest.mark.parametrize(
+    "par", [(par4), (par4j), (par5), (par5j), (par6), (par6b), (par7), (par7b)]
+)
 def test_redistribute(par):
     x_gpu = cp.asarray(par["x"])
     dist_array = DistributedArray.to_dist(
@@ -206,9 +274,11 @@ def test_redistribute(par):
         partition=par["partition"],
         axis=par["axis"],
     )
-    redist_array = dist_array.redistribute(axis=par['axis'] - 1)
+    redist_array = dist_array.redistribute(axis=par["axis"] - 1)
     assert isinstance(redist_array, DistributedArray)
-    assert_allclose(dist_array.asarray().get(), redist_array.asarray().get(), rtol=1e-13)
+    assert_allclose(
+        dist_array.asarray().get(), redist_array.asarray().get(), rtol=1e-13
+    )
 
 
 @pytest.mark.mpi(min_size=2)
@@ -247,29 +317,50 @@ def test_distributed_math_nccl(par1, par2):
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par1, par2", [(par6, par7), (par6b, par7b),
-                                        (par8, par9), (par8b, par9b)])
+@pytest.mark.parametrize(
+    "par1, par2", [(par6, par7), (par6b, par7b), (par8, par9), (par8b, par9b)]
+)
 def test_distributed_dot_nccl(par1, par2):
     """Test Distributed Dot product"""
     x1_gpu = cp.asarray(par1["x"])
     x2_gpu = cp.asarray(par2["x"])
     arr1 = DistributedArray.to_dist(
-        x=x1_gpu, base_comm_nccl=nccl_comm, partition=par1["partition"], axis=par1["axis"]
+        x=x1_gpu,
+        base_comm_nccl=nccl_comm,
+        partition=par1["partition"],
+        axis=par1["axis"],
     )
     arr2 = DistributedArray.to_dist(
-        x=x2_gpu, base_comm_nccl=nccl_comm, partition=par2["partition"], axis=par2["axis"]
+        x=x2_gpu,
+        base_comm_nccl=nccl_comm,
+        partition=par2["partition"],
+        axis=par2["axis"],
     )
     assert_allclose(
-        (arr1.dot(arr2)).get(),
+        arr1.dot(arr2),
         np.dot(par1["x"].flatten(), par2["x"].flatten()),
         rtol=1e-14,
     )
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par4), (par4j), (par5), (par5j),
-                                 (par6), (par6b), (par7), (par7b),
-                                 (par8), (par8b), (par9), (par9b)])
+@pytest.mark.parametrize(
+    "par",
+    [
+        (par4),
+        (par4j),
+        (par5),
+        (par5j),
+        (par6),
+        (par6b),
+        (par7),
+        (par7b),
+        (par8),
+        (par8b),
+        (par9),
+        (par9b),
+    ],
+)
 def test_distributed_norm_nccl(par):
     """Test Distributed numpy.linalg.norm method"""
     x_gpu = cp.asarray(par["x"])
@@ -284,7 +375,7 @@ def test_distributed_norm_nccl(par):
         np.linalg.norm(par["x"], ord=np.inf, axis=par["norm_axis"]),
         rtol=1e-14,
     )
-    assert_allclose(arr.norm().get(), np.linalg.norm(par["x"].flatten()), rtol=1e-13)
+    assert_allclose(arr.norm(), np.linalg.norm(par["x"].flatten()), rtol=1e-13)
 
 
 @pytest.mark.mpi(min_size=2)
@@ -302,15 +393,23 @@ def test_distributed_masked_nccl(par):
     mask = np.repeat(np.arange(nsub), subsize)
 
     # Replicate x as required in masked arrays
-    x_gpu = cp.asarray(par['x'])
-    if par['axis'] != 0:
-        x_gpu = cp.swapaxes(x_gpu, par['axis'], 0)
+    x_gpu = cp.asarray(par["x"])
+    if par["axis"] != 0:
+        x_gpu = cp.swapaxes(x_gpu, par["axis"], 0)
     for isub in range(1, nsub):
-        x_gpu[(x_gpu.shape[0] // nsub) * isub:(x_gpu.shape[0] // nsub) * (isub + 1)] = x_gpu[:x_gpu.shape[0] // nsub]
-    if par['axis'] != 0:
-        x_gpu = np.swapaxes(x_gpu, 0, par['axis'])
+        x_gpu[
+            (x_gpu.shape[0] // nsub) * isub : (x_gpu.shape[0] // nsub) * (isub + 1)
+        ] = x_gpu[: x_gpu.shape[0] // nsub]
+    if par["axis"] != 0:
+        x_gpu = np.swapaxes(x_gpu, 0, par["axis"])
 
-    arr = DistributedArray.to_dist(x=x_gpu, base_comm_nccl=nccl_comm, partition=par['partition'], mask=mask, axis=par['axis'])
+    arr = DistributedArray.to_dist(
+        x=x_gpu,
+        base_comm_nccl=nccl_comm,
+        partition=par["partition"],
+        mask=mask,
+        axis=par["axis"],
+    )
 
     # Global view
     xloc = arr.asarray()
@@ -319,13 +418,14 @@ def test_distributed_masked_nccl(par):
     # Global masked view
     xmaskedloc = arr.asarray(masked=True)
     xmasked_shape = list(x_gpu.shape)
-    xmasked_shape[par['axis']] = int(xmasked_shape[par['axis']] // nsub)
+    xmasked_shape[par["axis"]] = int(xmasked_shape[par["axis"]] // nsub)
     assert xmaskedloc.shape == tuple(xmasked_shape)
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par1, par2", [(par6, par7), (par6b, par7b),
-                                        (par8, par9), (par8b, par9b)])
+@pytest.mark.parametrize(
+    "par1, par2", [(par6, par7), (par6b, par7b), (par8, par9), (par8b, par9b)]
+)
 def test_distributed_maskeddot_nccl(par1, par2):
     """Test Distributed Dot product with masked array"""
     # number of subcommunicators
@@ -372,13 +472,14 @@ def test_distributed_maskeddot_nccl(par1, par2):
         axis=par2["axis"],
     )
     assert_allclose(
-        arr1.dot(arr2).get(), np.dot(x1.flatten(), x2.flatten()) / nsub, rtol=1e-14
+        arr1.dot(arr2), np.dot(x1.flatten(), x2.flatten()) / nsub, rtol=1e-14
     )
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par6), (par6b), (par7), (par7b),
-                                 (par8), (par8b), (par9), (par9b)])
+@pytest.mark.parametrize(
+    "par", [(par6), (par6b), (par7), (par7b), (par8), (par8b), (par9), (par9b)]
+)
 def test_distributed_maskednorm_nccl(par):
     """Test Distributed numpy.linalg.norm method with masked array"""
     # number of subcommunicators
@@ -406,17 +507,19 @@ def test_distributed_maskednorm_nccl(par):
         x=x_gpu, base_comm_nccl=nccl_comm, mask=mask, axis=par["axis"]
     )
     assert_allclose(
-        arr.norm(ord=1, axis=par['norm_axis']).get(),
-        np.linalg.norm(par['x'], ord=1, axis=par['norm_axis']) / (nsub if par['axis'] == par['norm_axis'] else 1),
-        rtol=1e-14
+        arr.norm(ord=1, axis=par["norm_axis"]).get(),
+        np.linalg.norm(par["x"], ord=1, axis=par["norm_axis"])
+        / (nsub if par["axis"] == par["norm_axis"] else 1),
+        rtol=1e-14,
     )
     assert_allclose(
-        arr.norm(ord=2, axis=par['norm_axis']).get(),
-        np.linalg.norm(par['x'], ord=2, axis=par['norm_axis']) / (np.sqrt(nsub) if par['axis'] == par['norm_axis'] else 1),
-        rtol=1e-13
+        arr.norm(ord=2, axis=par["norm_axis"]).get(),
+        np.linalg.norm(par["x"], ord=2, axis=par["norm_axis"])
+        / (np.sqrt(nsub) if par["axis"] == par["norm_axis"] else 1),
+        rtol=1e-13,
     )
     assert_allclose(
-        arr.norm(ord=np.inf, axis=par['norm_axis']).get(),
-        np.linalg.norm(par['x'], ord=np.inf, axis=par['norm_axis']),
-        rtol=1e-14
+        arr.norm(ord=np.inf, axis=par["norm_axis"]).get(),
+        np.linalg.norm(par["x"], ord=np.inf, axis=par["norm_axis"]),
+        rtol=1e-14,
     )

--- a/tests_nccl/test_stackedarray_nccl.py
+++ b/tests_nccl/test_stackedarray_nccl.py
@@ -4,8 +4,8 @@
 
 This file employs the same test sets as test_stackedarray under NCCL environment
 """
-import numpy as np
 import cupy as cp
+import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
@@ -16,89 +16,127 @@ nccl_comm = initialize_nccl_comm()
 
 np.random.seed(42)
 
-par1 = {'global_shape': (500, 501),
-        'partition': Partition.SCATTER, 'dtype': np.float64,
-        'axis': 1}
-par1j = {'global_shape': (501, 500),
-         'partition': Partition.SCATTER, 'dtype': np.complex128,
-         'axis': 0}
-par2 = {'global_shape': (500, 501),
-        'partition': Partition.BROADCAST, 'dtype': np.float64,
-        'axis': 1}
-par2j = {'global_shape': (501, 500),
-         'partition': Partition.BROADCAST, 'dtype': np.complex128,
-         'axis': 0}
+par1 = {
+    "global_shape": (500, 501),
+    "partition": Partition.SCATTER,
+    "dtype": np.float64,
+    "axis": 1,
+}
+par1j = {
+    "global_shape": (501, 500),
+    "partition": Partition.SCATTER,
+    "dtype": np.complex128,
+    "axis": 0,
+}
+par2 = {
+    "global_shape": (500, 501),
+    "partition": Partition.BROADCAST,
+    "dtype": np.float64,
+    "axis": 1,
+}
+par2j = {
+    "global_shape": (501, 500),
+    "partition": Partition.BROADCAST,
+    "dtype": np.complex128,
+    "axis": 0,
+}
 
-par3 = {'global_shape': (200, 201, 101),
-        'partition': Partition.SCATTER,
-        'dtype': np.float64, 'axis': 1}
+par3 = {
+    "global_shape": (200, 201, 101),
+    "partition": Partition.SCATTER,
+    "dtype": np.float64,
+    "axis": 1,
+}
 
-par3j = {'global_shape': (200, 201, 101),
-         'partition': Partition.SCATTER,
-         'dtype': np.complex128, 'axis': 2}
+par3j = {
+    "global_shape": (200, 201, 101),
+    "partition": Partition.SCATTER,
+    "dtype": np.complex128,
+    "axis": 2,
+}
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par1j), (par2),
-                                 (par2j), (par3), (par3j)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j), (par3), (par3j)])
 def test_creation_nccl(par):
     """Test creation of stacked distributed arrays"""
     # Create stacked array
-    distributed_array0 = DistributedArray(global_shape=par['global_shape'],
-                                          base_comm_nccl=nccl_comm,
-                                          partition=par['partition'],
-                                          dtype=par['dtype'], axis=par['axis'],
-                                          engine="cupy")
-    distributed_array1 = DistributedArray(global_shape=par['global_shape'],
-                                          base_comm_nccl=nccl_comm,
-                                          partition=par['partition'],
-                                          dtype=par['dtype'], axis=par['axis'],
-                                          engine="cupy")
+    distributed_array0 = DistributedArray(
+        global_shape=par["global_shape"],
+        base_comm_nccl=nccl_comm,
+        partition=par["partition"],
+        dtype=par["dtype"],
+        axis=par["axis"],
+        engine="cupy",
+    )
+    distributed_array1 = DistributedArray(
+        global_shape=par["global_shape"],
+        base_comm_nccl=nccl_comm,
+        partition=par["partition"],
+        dtype=par["dtype"],
+        axis=par["axis"],
+        engine="cupy",
+    )
     distributed_array0[:] = 0
     distributed_array1[:] = 1
 
     stacked_arrays = StackedDistributedArray([distributed_array0, distributed_array1])
     assert isinstance(stacked_arrays, StackedDistributedArray)
-    assert stacked_arrays.global_shape == tuple(gs * 2 for gs in par['global_shape'])
-    assert_allclose(stacked_arrays[0].local_array.get(),
-                    np.zeros(shape=distributed_array0.local_shape,
-                             dtype=par['dtype']), rtol=1e-14)
-    assert_allclose(stacked_arrays[1].local_array.get(),
-                    np.ones(shape=distributed_array1.local_shape,
-                            dtype=par['dtype']), rtol=1e-14)
+    assert stacked_arrays.global_shape == tuple(gs * 2 for gs in par["global_shape"])
+    assert_allclose(
+        stacked_arrays[0].local_array.get(),
+        np.zeros(shape=distributed_array0.local_shape, dtype=par["dtype"]),
+        rtol=1e-14,
+    )
+    assert_allclose(
+        stacked_arrays[1].local_array.get(),
+        np.ones(shape=distributed_array1.local_shape, dtype=par["dtype"]),
+        rtol=1e-14,
+    )
 
     # Asarray
     stacked_arrays_local = stacked_arrays.asarray().get()
-    stacked_arrays_local_bench = np.hstack([
-        np.zeros(shape=distributed_array0.global_shape, dtype=par['dtype']).ravel(),
-        np.ones(shape=distributed_array1.global_shape, dtype=par['dtype']).ravel(),
-        ])
+    stacked_arrays_local_bench = np.hstack(
+        [
+            np.zeros(shape=distributed_array0.global_shape, dtype=par["dtype"]).ravel(),
+            np.ones(shape=distributed_array1.global_shape, dtype=par["dtype"]).ravel(),
+        ]
+    )
     assert_allclose(stacked_arrays_local, stacked_arrays_local_bench, rtol=1e-14)
 
     # Modify array in place
     distributed_array0[:] = 2
-    assert_allclose(stacked_arrays[0].local_array.get(),
-                    2 * np.ones(shape=distributed_array0.local_shape,
-                                dtype=par['dtype']), rtol=1e-14)
+    assert_allclose(
+        stacked_arrays[0].local_array.get(),
+        2 * np.ones(shape=distributed_array0.local_shape, dtype=par["dtype"]),
+        rtol=1e-14,
+    )
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par1j), (par2),
-                                 (par2j), (par3), (par3j)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j), (par3), (par3j)])
 def test_stacked_math_nccl(par):
     """Test the Element-Wise Addition, Subtraction and Multiplication, Dot-product, Norm"""
-    distributed_array0 = DistributedArray(global_shape=par['global_shape'],
-                                          base_comm_nccl=nccl_comm,
-                                          partition=par['partition'],
-                                          dtype=par['dtype'], axis=par['axis'],
-                                          engine="cupy")
-    distributed_array1 = DistributedArray(global_shape=par['global_shape'],
-                                          base_comm_nccl=nccl_comm,
-                                          partition=par['partition'],
-                                          dtype=par['dtype'], axis=par['axis'],
-                                          engine="cupy")
+    distributed_array0 = DistributedArray(
+        global_shape=par["global_shape"],
+        base_comm_nccl=nccl_comm,
+        partition=par["partition"],
+        dtype=par["dtype"],
+        axis=par["axis"],
+        engine="cupy",
+    )
+    distributed_array1 = DistributedArray(
+        global_shape=par["global_shape"],
+        base_comm_nccl=nccl_comm,
+        partition=par["partition"],
+        dtype=par["dtype"],
+        axis=par["axis"],
+        engine="cupy",
+    )
     distributed_array0[:] = 0
-    distributed_array1[:] = cp.arange(np.prod(distributed_array1.local_shape)).reshape(distributed_array1.local_shape)
+    distributed_array1[:] = cp.arange(np.prod(distributed_array1.local_shape)).reshape(
+        distributed_array1.local_shape
+    )
 
     stacked_array1 = StackedDistributedArray([distributed_array0, distributed_array1])
     stacked_array2 = StackedDistributedArray([distributed_array1, distributed_array0])
@@ -106,115 +144,173 @@ def test_stacked_math_nccl(par):
     # Addition
     sum_array = stacked_array1 + stacked_array2
     assert isinstance(sum_array, StackedDistributedArray)
-    assert_allclose(sum_array.asarray().get(), np.add(stacked_array1.asarray().get(),
-                    stacked_array2.asarray().get()), rtol=1e-14)
+    assert_allclose(
+        sum_array.asarray().get(),
+        np.add(stacked_array1.asarray().get(), stacked_array2.asarray().get()),
+        rtol=1e-14,
+    )
     # Subtraction
     sub_array = stacked_array1 - stacked_array2
     assert isinstance(sub_array, StackedDistributedArray)
-    assert_allclose(sub_array.asarray().get(), np.subtract(stacked_array1.asarray().get(),
-                    stacked_array2.asarray().get()), rtol=1e-14)
+    assert_allclose(
+        sub_array.asarray().get(),
+        np.subtract(stacked_array1.asarray().get(), stacked_array2.asarray().get()),
+        rtol=1e-14,
+    )
     # Multiplication
     mult_array = stacked_array1 * stacked_array2
     assert isinstance(mult_array, StackedDistributedArray)
-    assert_allclose(mult_array.asarray().get(), np.multiply(stacked_array1.asarray().get(),
-                    stacked_array2.asarray().get()), rtol=1e-14)
+    assert_allclose(
+        mult_array.asarray().get(),
+        np.multiply(stacked_array1.asarray().get(), stacked_array2.asarray().get()),
+        rtol=1e-14,
+    )
     # Dot-product
     dot_prod = stacked_array1.dot(stacked_array2)
-    assert_allclose(dot_prod.get(), np.dot(stacked_array1.asarray().flatten().get(),
-                    stacked_array2.asarray().flatten().get()), rtol=1e-14)
+    assert_allclose(
+        dot_prod,
+        np.dot(
+            stacked_array1.asarray().flatten().get(),
+            stacked_array2.asarray().flatten().get(),
+        ),
+        rtol=1e-14,
+    )
     # Norm
     l0norm = stacked_array1.norm(0)
     l1norm = stacked_array1.norm(1)
     l2norm = stacked_array1.norm(2)
 
     linfnorm = stacked_array1.norm(np.inf)
-    assert_allclose(l0norm.get(), np.linalg.norm(stacked_array1.asarray().flatten().get(), 0),
-                    rtol=1e-14)
-    assert_allclose(l1norm.get(), np.linalg.norm(stacked_array1.asarray().flatten().get(), 1),
-                    rtol=1e-14)
-    assert_allclose(l2norm.get(), np.linalg.norm(stacked_array1.asarray().get(), 2),
-                    rtol=1e-10)  # needed to raise it due to how partial norms are combined (with power applied)
-    assert_allclose(linfnorm.get(), np.linalg.norm(stacked_array1.asarray().flatten().get(), np.inf),
-                    rtol=1e-14)
+    assert_allclose(
+        l0norm, np.linalg.norm(stacked_array1.asarray().flatten().get(), 0), rtol=1e-14
+    )
+    assert_allclose(
+        l1norm, np.linalg.norm(stacked_array1.asarray().flatten().get(), 1), rtol=1e-14
+    )
+    assert_allclose(
+        l2norm, np.linalg.norm(stacked_array1.asarray().get(), 2), rtol=1e-10
+    )  # needed to raise it due to how partial norms are combined (with power applied)
+    assert_allclose(
+        linfnorm,
+        np.linalg.norm(stacked_array1.asarray().flatten().get(), np.inf),
+        rtol=1e-14,
+    )
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par1j), (par2),
-                                 (par2j), (par3), (par3j)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j), (par3), (par3j)])
 def test_creation_nested(par):
     """Test creation of nested stacked distributed arrays"""
     # Create stacked array
-    distributed_array0 = DistributedArray(global_shape=par['global_shape'],
-                                          partition=par['partition'],
-                                          dtype=par['dtype'], axis=par['axis'],
-                                          engine="cupy")
-    distributed_array1 = DistributedArray(global_shape=par['global_shape'],
-                                          partition=par['partition'],
-                                          dtype=par['dtype'], axis=par['axis'],
-                                          engine="cupy")
-    distributed_array2 = DistributedArray(global_shape=[gs * 2 for gs in par['global_shape']],
-                                          partition=par['partition'],
-                                          dtype=par['dtype'], axis=par['axis'],
-                                          engine="cupy")
+    distributed_array0 = DistributedArray(
+        global_shape=par["global_shape"],
+        partition=par["partition"],
+        dtype=par["dtype"],
+        axis=par["axis"],
+        engine="cupy",
+    )
+    distributed_array1 = DistributedArray(
+        global_shape=par["global_shape"],
+        partition=par["partition"],
+        dtype=par["dtype"],
+        axis=par["axis"],
+        engine="cupy",
+    )
+    distributed_array2 = DistributedArray(
+        global_shape=[gs * 2 for gs in par["global_shape"]],
+        partition=par["partition"],
+        dtype=par["dtype"],
+        axis=par["axis"],
+        engine="cupy",
+    )
     distributed_array0[:] = 0
     distributed_array1[:] = 1
     distributed_array2[:] = 2
 
-    stacked_arrays_01 = StackedDistributedArray([distributed_array0, distributed_array1])
+    stacked_arrays_01 = StackedDistributedArray(
+        [distributed_array0, distributed_array1]
+    )
     stacked_arrays = StackedDistributedArray([stacked_arrays_01, distributed_array2])
     assert isinstance(stacked_arrays, StackedDistributedArray)
-    assert stacked_arrays.global_shape == tuple(gs * 4 for gs in par['global_shape'])
-    assert_allclose(stacked_arrays[0][0].local_array.get(),
-                    np.zeros(shape=distributed_array0.local_shape,
-                             dtype=par['dtype']), rtol=1e-14)
-    assert_allclose(stacked_arrays[0][1].local_array.get(),
-                    np.ones(shape=distributed_array1.local_shape,
-                             dtype=par['dtype']), rtol=1e-14)
-    assert_allclose(stacked_arrays[1].local_array.get(),
-                    2 * np.ones(shape=distributed_array2.local_shape,
-                                dtype=par['dtype']), rtol=1e-14)
+    assert stacked_arrays.global_shape == tuple(gs * 4 for gs in par["global_shape"])
+    assert_allclose(
+        stacked_arrays[0][0].local_array.get(),
+        np.zeros(shape=distributed_array0.local_shape, dtype=par["dtype"]),
+        rtol=1e-14,
+    )
+    assert_allclose(
+        stacked_arrays[0][1].local_array.get(),
+        np.ones(shape=distributed_array1.local_shape, dtype=par["dtype"]),
+        rtol=1e-14,
+    )
+    assert_allclose(
+        stacked_arrays[1].local_array.get(),
+        2 * np.ones(shape=distributed_array2.local_shape, dtype=par["dtype"]),
+        rtol=1e-14,
+    )
 
     # Asarray
     stacked_arrays_local = stacked_arrays.asarray().get()
-    stacked_arrays_local_bench = np.hstack([
-        np.zeros(shape=distributed_array0.global_shape, dtype=par['dtype']).ravel(),
-        np.ones(shape=distributed_array1.global_shape, dtype=par['dtype']).ravel(),
-        2 * np.ones(shape=distributed_array2.global_shape, dtype=par['dtype']).ravel(),
-        ])
+    stacked_arrays_local_bench = np.hstack(
+        [
+            np.zeros(shape=distributed_array0.global_shape, dtype=par["dtype"]).ravel(),
+            np.ones(shape=distributed_array1.global_shape, dtype=par["dtype"]).ravel(),
+            2
+            * np.ones(
+                shape=distributed_array2.global_shape, dtype=par["dtype"]
+            ).ravel(),
+        ]
+    )
     assert_allclose(stacked_arrays_local, stacked_arrays_local_bench, rtol=1e-14)
 
     # Modify array in place
     distributed_array0[:] = 2
-    assert_allclose(stacked_arrays[0][0].local_array.get(),
-                    2 * np.ones(shape=distributed_array0.local_shape,
-                                dtype=par['dtype']), rtol=1e-14)
+    assert_allclose(
+        stacked_arrays[0][0].local_array.get(),
+        2 * np.ones(shape=distributed_array0.local_shape, dtype=par["dtype"]),
+        rtol=1e-14,
+    )
     distributed_array2[:] = 4
-    assert_allclose(stacked_arrays[1].local_array.get(),
-                    4 * np.ones(shape=distributed_array2.local_shape,
-                                dtype=par['dtype']), rtol=1e-14)
+    assert_allclose(
+        stacked_arrays[1].local_array.get(),
+        4 * np.ones(shape=distributed_array2.local_shape, dtype=par["dtype"]),
+        rtol=1e-14,
+    )
 
 
 @pytest.mark.mpi(min_size=2)
-@pytest.mark.parametrize("par", [(par1), (par1j), (par2),
-                                 (par2j), (par3), (par3j)])
+@pytest.mark.parametrize("par", [(par1), (par1j), (par2), (par2j), (par3), (par3j)])
 def test_stacked_nested_math(par):
     """Test Element-Wise Addition, Subtraction and Multiplication, Dot-product, Norm
     for nested stacked distributed arrays"""
-    distributed_array0 = DistributedArray(global_shape=par['global_shape'],
-                                          partition=par['partition'],
-                                          dtype=par['dtype'], axis=par['axis'],
-                                          engine="cupy")
-    distributed_array1 = DistributedArray(global_shape=par['global_shape'],
-                                          partition=par['partition'],
-                                          dtype=par['dtype'], axis=par['axis'],
-                                          engine="cupy")
-    distributed_array2 = DistributedArray(global_shape=par['global_shape'],
-                                          partition=par['partition'],
-                                          dtype=par['dtype'], axis=par['axis'],
-                                          engine="cupy")
+    distributed_array0 = DistributedArray(
+        global_shape=par["global_shape"],
+        partition=par["partition"],
+        dtype=par["dtype"],
+        axis=par["axis"],
+        engine="cupy",
+    )
+    distributed_array1 = DistributedArray(
+        global_shape=par["global_shape"],
+        partition=par["partition"],
+        dtype=par["dtype"],
+        axis=par["axis"],
+        engine="cupy",
+    )
+    distributed_array2 = DistributedArray(
+        global_shape=par["global_shape"],
+        partition=par["partition"],
+        dtype=par["dtype"],
+        axis=par["axis"],
+        engine="cupy",
+    )
     distributed_array0[:] = 0
-    distributed_array1[:] = cp.arange(np.prod(distributed_array1.local_shape)).reshape(distributed_array1.local_shape)
-    distributed_array2[:] = cp.ones(np.prod(distributed_array2.local_shape)).reshape(distributed_array1.local_shape)
+    distributed_array1[:] = cp.arange(np.prod(distributed_array1.local_shape)).reshape(
+        distributed_array1.local_shape
+    )
+    distributed_array2[:] = cp.ones(np.prod(distributed_array2.local_shape)).reshape(
+        distributed_array1.local_shape
+    )
 
     stacked_array_01 = StackedDistributedArray([distributed_array0, distributed_array1])
     stacked_array_12 = StackedDistributedArray([distributed_array1, distributed_array2])
@@ -224,37 +320,54 @@ def test_stacked_nested_math(par):
     # Addition
     sum_array = stacked_array1 + stacked_array2
     assert isinstance(sum_array, StackedDistributedArray)
-    assert_allclose(sum_array.asarray().get(), np.add(stacked_array1.asarray().get(),
-                                                      stacked_array2.asarray().get()),
-                    rtol=1e-14)
+    assert_allclose(
+        sum_array.asarray().get(),
+        np.add(stacked_array1.asarray().get(), stacked_array2.asarray().get()),
+        rtol=1e-14,
+    )
     # Subtraction
     sub_array = stacked_array1 - stacked_array2
     assert isinstance(sub_array, StackedDistributedArray)
-    assert_allclose(sub_array.asarray().get(), np.subtract(stacked_array1.asarray().get(),
-                                                           stacked_array2.asarray().get()),
-                    rtol=1e-14)
+    assert_allclose(
+        sub_array.asarray().get(),
+        np.subtract(stacked_array1.asarray().get(), stacked_array2.asarray().get()),
+        rtol=1e-14,
+    )
     # Multiplication
     mult_array = stacked_array1 * stacked_array2
     assert isinstance(mult_array, StackedDistributedArray)
-    assert_allclose(mult_array.asarray().get(), np.multiply(stacked_array1.asarray().get(),
-                                                            stacked_array2.asarray().get()),
-                    rtol=1e-14)
+    assert_allclose(
+        mult_array.asarray().get(),
+        np.multiply(stacked_array1.asarray().get(), stacked_array2.asarray().get()),
+        rtol=1e-14,
+    )
     # Dot-product
     dot_prod = stacked_array1.dot(stacked_array2)
-    assert_allclose(dot_prod.get(), np.dot(stacked_array1.asarray().flatten().get(),
-                                           stacked_array2.asarray().flatten().get()),
-                    rtol=1e-14)
+    assert_allclose(
+        dot_prod,
+        np.dot(
+            stacked_array1.asarray().flatten().get(),
+            stacked_array2.asarray().flatten().get(),
+        ),
+        rtol=1e-14,
+    )
     # Norm
     l0norm = stacked_array1.norm(0)
     l1norm = stacked_array1.norm(1)
     l2norm = stacked_array1.norm(2)
     linfnorm = stacked_array1.norm(np.inf)
 
-    assert_allclose(l0norm.get(), np.linalg.norm(stacked_array1.asarray().flatten().get(), 0),
-                    rtol=1e-14)
-    assert_allclose(l1norm.get(), np.linalg.norm(stacked_array1.asarray().flatten().get(), 1),
-                    rtol=1e-14)
-    assert_allclose(l2norm.get(), np.linalg.norm(stacked_array1.asarray().get(), 2),
-                    rtol=1e-10)
-    assert_allclose(linfnorm.get(), np.linalg.norm(stacked_array1.asarray().flatten().get(), np.inf),
-                    rtol=1e-14)
+    assert_allclose(
+        l0norm, np.linalg.norm(stacked_array1.asarray().flatten().get(), 0), rtol=1e-14
+    )
+    assert_allclose(
+        l1norm, np.linalg.norm(stacked_array1.asarray().flatten().get(), 1), rtol=1e-14
+    )
+    assert_allclose(
+        l2norm, np.linalg.norm(stacked_array1.asarray().get(), 2), rtol=1e-10
+    )
+    assert_allclose(
+        linfnorm,
+        np.linalg.norm(stacked_array1.asarray().flatten().get(), np.inf),
+        rtol=1e-14,
+    )


### PR DESCRIPTION
# NumPy `ndim > 0` to-scalar deprecation: root cause and fix

## The warning

```
DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated,
and will error in future. Ensure you extract a single element from your array before
performing this operation. (Deprecated NumPy 1.25.)
```

Triggered by any caller doing `float(...)` on the result of `DistributedArray.norm()`, because `norm()` never actually returned a scalar.

## Root cause

`DistributedArray.norm()` documented a `float` return but returned a **shape-`(1,)` array**:

1. `norm(axis=None)` flattens the local array and calls
   `_compute_vector_norm(..., axis=0, ord=ord)`.
2. That reduces via `_allreduce_subcomm`.
3. `mpi_allreduce` (`pylops_mpi/utils/_mpi.py:104`) always allocates
   `recv_buf = ncp.zeros(send_buf.size, dtype=...)` — a **1-D** buffer. For a scalar
   reduction `send_buf.size == 1`, so the result is `array([...])` with
   `ndim == 1, size == 1`.

`float()` on such an array is the deprecated implicit array-to-scalar conversion (an error in a future NumPy).

`DistributedArray.dot()` had the identical issue: it returned the raw size-1 allreduce buffer.

## The fix

New module-level helper in `pylops_mpi/DistributedArray.py`:

```python
def to_scalar(x) -> Union[bool, int, float, complex]:
    return x.item() if hasattr(x, "item") else x
```

- Backend-agnostic: `.item()` works for numpy and cupy arrays, and the
  `hasattr` guard covers the non-buffered-MPI paths that already return a
  plain scalar.
- **Dtype-preserving** — returns `float` in most cases, but for example
  a complex `vdot` stays `complex`.

Applied to:

| Location | Change |
|---|---|
| `DistributedArray.norm` (`axis=None` branch) | returns `float`; docstring notes scalar vs array per `axis` |
| `DistributedArray.dot` | returns `float`/`complex`; docstring return type fixed |
| `StackedDistributedArray.norm` | returns `float`; return annotation `bool \| float` -> `float` |

`norm(axis=...)` is unchanged and still returns an array.

`StackedDistributedArray.norm` **had** to change beyond the return value: it aggregated the per-array norms with `ncp.hstack(...)`, and since those are now host scalars, `cupy.hstack` on them would raise. It now aggregates with numpy (correct, because the inputs are host scalars).

## Call sites updated

`float` has no `.item()`, so every `.norm().item()` / `.dot(...).item()` chain had to be simplified.

- `pylops_mpi/optimization/cls_basic.py` — 10 spots across CG/CGLS. Note
  `a = float((self.kold / cOpc).item())` -> `float(self.kold / cOpc)` would have
  raised `AttributeError` otherwise (both operands are plain scalars now).
- `pylops_mpi/optimization/cls_sparsity.py` — 6 spots in ISTA/FISTA
  (`xupdate`, `costdata`, `costreg`).
- `pylops_mpi/optimization/eigs.py:86` — `b_k.dot(b1_k, vdot=True).item()` ->
  `b_k.dot(b1_k, vdot=True)`.
- `tests_nccl/test_distributedarray_nccl.py`, `tests_nccl/test_stackedarray_nccl.py`
  — the GPU tests called `.get()` on `dot()` / axis-less `norm()` results, which
  would now be `AttributeError` on a Python scalar. Removed on the 3 `dot` and 9
  `norm` assertions; **kept** on `norm(axis=...)`, which still returns a cupy array.

## Behaviour change to be aware of (cupy)

`norm(axis=None)` and `dot()` now return **host** scalars instead of device size-1 arrays, so they force a device-to-host sync. Nearly every call site already did `.item()` (same sync); the rest only divide a `DistributedArray` by the result, which is fine with a host scalar.